### PR TITLE
Implement related posts feature in post layout +semver: minor

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -177,6 +177,70 @@
           {% endfor %}
         </div>
         {% endif %}
+
+        {% comment %}── Related posts — scored by shared tags (+1 each) and categories (+2 each) ──{% endcomment %}
+        {% assign scored = "" | split: "" %}
+        {% for candidate in site.posts %}
+          {% unless candidate.url == page.url %}
+            {% assign score = 0 %}
+            {% for cat in page.categories %}
+              {% if candidate.categories contains cat %}
+                {% assign score = score | plus: 2 %}
+              {% endif %}
+            {% endfor %}
+            {% for tag in page.tags %}
+              {% if candidate.tags contains tag %}
+                {% assign score = score | plus: 1 %}
+              {% endif %}
+            {% endfor %}
+            {% if score > 0 %}
+              {% assign padded = score | prepend: "000" | slice: -3, 3 %}
+              {% assign entry = padded | append: "|" | append: candidate.url %}
+              {% assign scored = scored | push: entry %}
+            {% endif %}
+          {% endunless %}
+        {% endfor %}
+
+        {% assign scored = scored | sort | reverse %}
+        {% assign top_urls = "" | split: "" %}
+        {% for entry in scored limit: 3 %}
+          {% assign parts = entry | split: "|" %}
+          {% assign top_urls = top_urls | push: parts[1] %}
+        {% endfor %}
+
+        {% assign related_posts = "" | split: "" %}
+        {% for url in top_urls %}
+          {% for candidate in site.posts %}
+            {% if candidate.url == url %}
+              {% assign related_posts = related_posts | push: candidate %}
+            {% endif %}
+          {% endfor %}
+        {% endfor %}
+
+        {% if related_posts.size > 0 %}
+        <div class="related-posts">
+          <p class="related-title">Artigos relacionados</p>
+          <div class="related-grid">
+            {% for post in related_posts %}
+            <a href="{{ post.url | relative_url }}" class="related-card">
+              {% if post.image %}
+              <div class="related-card-image" style="background-image: url('{{ post.image | relative_url }}');"></div>
+              {% else %}
+              <div class="related-card-image related-card-placeholder">{{ post.title | slice: 0 }}</div>
+              {% endif %}
+              <div class="related-card-body">
+                <p class="related-card-title">{{ post.title }}</p>
+                <p class="related-card-meta">
+                  {{ post.date | date: "%d/%m/%Y" }}
+                  {% if post.reading_time %} · ~{{ post.reading_time }} min{% endif %}
+                </p>
+              </div>
+            </a>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+
       </div>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -813,3 +813,17 @@ a { color: inherit; text-decoration: none; }
   .providers-grid { grid-template-columns: 1fr; }
   .simbox-specs { grid-template-columns: 1fr 1fr; }
 }
+
+/* ── Related posts ─────────────────────────────────────────────────────────── */
+.related-posts { padding: 2.5rem 0 1rem; border-top: 1px solid var(--border); margin-top: 2rem; }
+.related-title { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--ink-light); margin-bottom: 1.25rem; }
+.related-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+.related-card { text-decoration: none; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; transition: border-color .2s, transform .2s; display: flex; flex-direction: column; }
+.related-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+.related-card-image { height: 120px; background-size: cover; background-position: center; background-color: var(--ink); flex-shrink: 0; }
+.related-card-placeholder { display: flex; align-items: center; justify-content: center; font-family: 'Playfair Display', serif; font-size: 2.5rem; color: var(--ink-light); }
+.related-card-body { padding: .75rem 1rem; flex: 1; display: flex; flex-direction: column; justify-content: space-between; }
+.related-card-title { font-family: 'Source Serif 4', serif; font-size: .9rem; color: var(--ink); line-height: 1.4; margin-bottom: .4rem; }
+.related-card-meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-light); }
+@media (max-width: 860px) { .related-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px) { .related-grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
## 📑 Description
Added logic to display related posts based on shared tags and categories, enhancing content discovery.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

New Features:
- Display up to three related posts on each post page, ranked by shared tags and categories, to improve content discovery.