### PR TITLE
style: improve post metadata readability

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -173,7 +173,7 @@
               {% endif %}
               <div class="post-card-meta">
                 <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                {% if post.reading_time %}<span>{{ post.reading_time }} min</span>{% endif %}
+                {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
               </div>
             </div>
           </article>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -174,7 +174,7 @@
                 {% endif %}
                 <div class="post-card-meta">
                   <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                  {% if post.reading_time %}<span>{{ post.reading_time }} min</span>{% endif %}
+                  {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
                 </div>
               </div>
             </article>

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@ layout: null
                 {% endif %}
                 <div class="post-card-meta">
                   <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                  {% if post.reading_time %}<span>{{ post.reading_time }} min</span>{% endif %}
+                  {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
                 </div>
               </div>
             </article>


### PR DESCRIPTION
## 📑 Description
Add a clock icon before the reading time estimate in the post metadata sections of category, tag, and index pages. This change makes the reading time information more visually distinct and enhances user experience by clearly indicating the time aspect of the metadata. Using a font-awesome icon for the clock improves the aesthetic and quick understanding of the data.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Improve the readability of post metadata by enhancing the display of reading time across listing pages.

New Features:
- Display a clock icon alongside the reading time in post metadata on category, tag, and index pages.

Enhancements:
- Standardize the reading-time label format with a prefixed '~' symbol to indicate an approximate duration.