### PR TITLE
feat: add GitHub Pages deploy workflow and pagination

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Jekyll to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-feed"
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"
+gem "jekyll-paginate-v2"

--- a/_config.yml
+++ b/_config.yml
@@ -45,14 +45,20 @@ kramdown:
 
 # ── Plugins ─────────────────────────────────────────────
 plugins:
-  - jekyll-feed        # /feed.xml gerado automaticamente
-  - jekyll-seo-tag     # meta tags open graph e twitter card
-  - jekyll-sitemap     # /sitemap.xml gerado automaticamente
+  - jekyll-feed
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jekyll-paginate-v2
 
 # ── Paginação ───────────────────────────────────────────
-paginate: 10
-paginate_path: "/pagina/:num/"
 featured_limit: 2
+
+pagination:
+  enabled: true
+  per_page: 9
+  permalink: '/pagina/:num/'
+  sort_field: 'date'
+  sort_reverse: true
 
 # ── Feed RSS ────────────────────────────────────────────
 feed:

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,0 +1,15 @@
+{% if paginator.total_pages > 1 %}
+<nav class="pagination" aria-label="Navegação de páginas">
+  {% if paginator.previous_page %}
+  <a class="pagination-btn" href="{{ paginator.previous_page_path | relative_url }}">← Anterior</a>
+  {% else %}
+  <span class="pagination-btn pagination-disabled">← Anterior</span>
+  {% endif %}
+  <span class="pagination-info">{{ paginator.page }} / {{ paginator.total_pages }}</span>
+  {% if paginator.next_page %}
+  <a class="pagination-btn" href="{{ paginator.next_page_path | relative_url }}">Próximo →</a>
+  {% else %}
+  <span class="pagination-btn pagination-disabled">Próximo →</span>
+  {% endif %}
+</nav>
+{% endif %}

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -128,18 +128,15 @@
     <section class="hero">
       <p class="hero-eyebrow">// categoria //</p>
       <h1 class="hero-title">{{ page.category }}</h1>
-      {% assign cat_posts = site.posts | where_exp: "post", "post.categories contains page.category" %}
       <p class="hero-desc">
-        {{ cat_posts | size }} artigo{% if cat_posts.size != 1 %}s{% endif %} publicado{% if cat_posts.size != 1 %}s{% endif %} nesta categoria.
+        {{ paginator.total_posts }} artigo{% if paginator.total_posts != 1 %}s{% endif %} publicado{% if paginator.total_posts != 1 %}s{% endif %} nesta categoria.
       </p>
     </section>
 
     <!-- Posts -->
     <div class="content-wrap">
 
-      {% assign cat_posts = site.posts | where_exp: "post", "post.categories contains page.category" %}
-
-      {% if cat_posts.size == 0 %}
+      {% if paginator.posts.size == 0 %}
         <div class="empty-state">
           <div class="empty-glyph">em breve.</div>
           <p>Nenhum artigo nesta categoria ainda.</p>
@@ -150,7 +147,7 @@
         </div>
 
         <div class="posts-grid">
-          {% for post in cat_posts %}
+          {% for post in paginator.posts %}
           <article class="post-card">
             <a href="{{ post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
               {% if post.image %}
@@ -179,6 +176,7 @@
           </article>
           {% endfor %}
         </div>
+        {% include pagination.html %}
       {% endif %}
 
     </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -495,6 +495,19 @@ a { color: inherit; text-decoration: none; }
   padding: 2px 8px; border-radius: 20px; margin-bottom: .5rem;
 }
 
+/* Pagination nav */
+.pagination {
+  display: flex; align-items: center; justify-content: center; gap: 1rem;
+  padding: 1.25rem 0 .25rem; font-family: 'JetBrains Mono', monospace; font-size: 0.7rem;
+}
+.pagination-btn {
+  padding: 5px 14px; border-radius: 6px; border: 1px solid var(--border);
+  color: var(--ink); text-decoration: none; transition: border-color .2s, color .2s;
+}
+a.pagination-btn:hover { border-color: var(--accent); color: var(--accent); }
+.pagination-disabled { opacity: .35; pointer-events: none; }
+.pagination-info { color: var(--ink-light); }
+
 /* Tags cloud */
 .tags-cloud { display: flex; flex-wrap: wrap; gap: 6px; }
 .tag-item {

--- a/categorias/career.md
+++ b/categorias/career.md
@@ -2,4 +2,7 @@
 layout: category
 category: Career
 permalink: /categorias/career/
+pagination:
+  enabled: true
+  category: Career
 ---

--- a/categorias/coding.md
+++ b/categorias/coding.md
@@ -2,4 +2,7 @@
 layout: category
 category: Coding
 permalink: /categorias/coding/
+pagination:
+  enabled: true
+  category: Coding
 ---

--- a/categorias/devops.md
+++ b/categorias/devops.md
@@ -2,4 +2,7 @@
 layout: category
 category: DevOps
 permalink: /categorias/devops/
+pagination:
+  enabled: true
+  category: DevOps
 ---

--- a/categorias/hobbies.md
+++ b/categorias/hobbies.md
@@ -2,4 +2,7 @@
 layout: category
 category: Hobbies
 permalink: /categorias/hobbies/
+pagination:
+  enabled: true
+  category: Hobbies
 ---

--- a/categorias/infraestrutura.md
+++ b/categorias/infraestrutura.md
@@ -2,4 +2,7 @@
 layout: category
 category: Infraestrutura
 permalink: /categorias/infraestrutura/
+pagination:
+  enabled: true
+  category: Infraestrutura
 ---

--- a/categorias/investments.md
+++ b/categorias/investments.md
@@ -2,4 +2,7 @@
 layout: category
 category: Investments
 permalink: /categorias/investments/
+pagination:
+  enabled: true
+  category: Investments
 ---

--- a/categorias/telecomunicacoes.md
+++ b/categorias/telecomunicacoes.md
@@ -2,4 +2,7 @@
 layout: category
 category: Telecomunicações
 permalink: /categorias/telecomunicacoes/
+pagination:
+  enabled: true
+  category: Telecomunicações
 ---

--- a/categorias/testing.md
+++ b/categorias/testing.md
@@ -2,4 +2,7 @@
 layout: category
 category: Testing
 permalink: /categorias/testing/
+pagination:
+  enabled: true
+  category: Testing
 ---

--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 ---
 layout: null
+pagination:
+  enabled: true
 ---
 <!DOCTYPE html>
 <html lang="pt-BR">
@@ -214,7 +216,7 @@ layout: null
           </div>
         </div>
 
-        {% assign regular_posts = site.posts | where_exp: "p", "p.featured != true" %}
+        {% assign regular_posts = paginator.posts | where_exp: "p", "p.featured != true" %}
         {% if regular_posts.size > 0 %}
         <div class="article-card">
           <div class="section-row">
@@ -250,17 +252,19 @@ layout: null
             </article>
             {% endfor %}
           </div>
+          {% include pagination.html %}
         </div>
         {% endif %}
 
         {% else %}
 
+        {% if paginator.page == 1 %}
         <!-- Card: destaque (fallback: post mais recente) -->
         <div class="article-card">
           <div class="section-row">
             <h2 class="section-title">Destaque</h2>
           </div>
-          {% assign featured = site.posts.first %}
+          {% assign featured = paginator.posts.first %}
           <article class="featured-card">
             <div class="featured-image">
               {% if featured.image %}
@@ -289,8 +293,13 @@ layout: null
             </div>
           </article>
         </div>
+        {% endif %}
 
-        {% assign other_posts = site.posts | shift %}
+        {% if paginator.page == 1 %}
+          {% assign other_posts = paginator.posts | shift %}
+        {% else %}
+          {% assign other_posts = paginator.posts %}
+        {% endif %}
         {% if other_posts.size > 0 %}
         <div class="article-card">
           <div class="section-row">
@@ -326,6 +335,7 @@ layout: null
             </article>
             {% endfor %}
           </div>
+          {% include pagination.html %}
         </div>
         {% endif %}
 


### PR DESCRIPTION
## 📑 Description
Introduce an automated workflow to deploy the Jekyll site to GitHub Pages, triggered by pushes to the main branch. This streamlines the deployment process and ensures consistent updates to the live site.

Enable pagination for posts, improving navigation
and user experience. The _config.yml and related
HTML files have been updated to support Jekyll
pagination, allowing better organization and access to content across multiple categories.

Add new dependencies for Jekyll plugins to the Gemfile, facilitating enhanced SEO, RSS feed generation, and advanced pagination features. These changes aim to enhance site functionality and performance.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add GitHub Pages deployment workflow and enable paginated post listings across the home and category pages.

New Features:
- Introduce automated GitHub Pages deployment for the Jekyll site via a dedicated workflow.
- Enable site-wide pagination using jekyll-paginate-v2 on the home page and category pages, including a reusable pagination navigation include.

Enhancements:
- Standardize Jekyll plugin configuration and add a Gemfile to declare site dependencies.
- Update category and index layouts to use paginator-aware metadata and post lists, including pagination-aware featured sections.
- Add styling for pagination controls in the main stylesheet.

CI:
- Add a GitHub Actions workflow to build the Jekyll site and deploy it to GitHub Pages on pushes to the main branch.