### PR TITLE
feat: add reading progress bar to post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,6 +15,8 @@
 </head>
 <body>
 
+  <div id="reading-progress" aria-hidden="true"></div>
+
   <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Abrir menu">
     <i class="fas fa-bars"></i>
   </button>
@@ -306,6 +308,12 @@
   </div><!-- /.main -->
 
   <script>
+    const bar = document.getElementById('reading-progress');
+    window.addEventListener('scroll', () => {
+      const doc = document.documentElement;
+      bar.style.width = Math.min(doc.scrollTop / (doc.scrollHeight - doc.clientHeight) * 100, 100) + '%';
+    }, { passive: true });
+
     const toggle  = document.getElementById('sidebar-toggle');
     const sidebar = document.getElementById('sidebar');
     const overlay = document.getElementById('sidebar-overlay');

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -495,6 +495,15 @@ a { color: inherit; text-decoration: none; }
   padding: 2px 8px; border-radius: 20px; margin-bottom: .5rem;
 }
 
+/* Reading progress bar */
+#reading-progress {
+  position: fixed; top: 0; left: 0;
+  height: 3px; width: 0%;
+  background: var(--accent);
+  z-index: 9999;
+  transition: width .1s linear;
+}
+
 /* Pagination nav */
 .pagination {
   display: flex; align-items: center; justify-content: center; gap: 1rem;


### PR DESCRIPTION
## 📑 Description
Introduce a reading progress bar at the top of the page to visually indicate how far a reader has scrolled through an article. This enhancement improves user experience by providing feedback on reading progress, especially for long articles. The progress bar is implemented as a fixed position element which updates its width based on the scroll position relative to the total document height.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

New Features:
- Display a fixed reading progress bar at the top of post pages that updates based on scroll position.