### PR TITLE
feat: add "back to top" button for improved navigation

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,6 +16,9 @@
 <body>
 
   <div id="reading-progress" aria-hidden="true"></div>
+  <button id="back-to-top" aria-label="Voltar ao topo" title="Voltar ao topo">
+    <i class="fas fa-arrow-up"></i>
+  </button>
 
   <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Abrir menu">
     <i class="fas fa-bars"></i>
@@ -309,10 +312,13 @@
 
   <script>
     const bar = document.getElementById('reading-progress');
+    const btt = document.getElementById('back-to-top');
     window.addEventListener('scroll', () => {
       const doc = document.documentElement;
       bar.style.width = Math.min(doc.scrollTop / (doc.scrollHeight - doc.clientHeight) * 100, 100) + '%';
+      btt.classList.toggle('visible', window.scrollY > 400);
     }, { passive: true });
+    btt.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
 
     const toggle  = document.getElementById('sidebar-toggle');
     const sidebar = document.getElementById('sidebar');

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -495,6 +495,20 @@ a { color: inherit; text-decoration: none; }
   padding: 2px 8px; border-radius: 20px; margin-bottom: .5rem;
 }
 
+/* Back to top button */
+#back-to-top {
+  position: fixed; bottom: 2rem; right: 2rem;
+  width: 40px; height: 40px; border-radius: 50%;
+  background: var(--accent); color: var(--bg);
+  border: none; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  opacity: 0; pointer-events: none;
+  transition: opacity .3s;
+  z-index: 100;
+}
+#back-to-top.visible { opacity: 1; pointer-events: auto; }
+@media (max-width: 600px) { #back-to-top { bottom: 5rem; } }
+
 /* Reading progress bar */
 #reading-progress {
   position: fixed; top: 0; left: 0;


### PR DESCRIPTION
## 📑 Description
Introduce a "back to top" button to the layout, allowing users to smoothly scroll back to the top of the page. This enhancement improves user experience by providing an intuitive navigation aid, especially on long pages. The button becomes visible when the user scrolls more than 400 pixels down the page and uses a smooth scroll animation for better visual feedback. Styling changes include positioning for both desktop and mobile views, ensuring the button is accessible and usable across devices.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a floating "back to top" control to post pages to improve navigation on long content.

New Features:
- Introduce a fixed-position "back to top" button that appears after scrolling down the page and scrolls smoothly to the top when clicked.

Enhancements:
- Adjust layout styling so the back-to-top button is appropriately positioned on desktop and mobile and does not interfere with existing UI elements.