### PR TITLE
feat: add breadcrumb navigation to layouts

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,0 +1,17 @@
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="{{ site.baseurl }}/">Home</a>
+  <span aria-hidden="true">›</span>
+  {% if page.layout == 'post' %}
+    {% for cat in page.categories limit: 1 %}
+    <a href="{{ site.baseurl }}/categorias/{{ cat | slugify: 'latin' }}/">{{ cat }}</a>
+    <span aria-hidden="true">›</span>
+    {% endfor %}
+    <span aria-current="page">{{ page.title | truncate: 50 }}</span>
+  {% elsif page.layout == 'category' %}
+    <span aria-current="page">{{ page.category }}</span>
+  {% elsif page.layout == 'tag' %}
+    <a href="{{ site.baseurl }}/topicos/">Tópicos</a>
+    <span aria-hidden="true">›</span>
+    <span aria-current="page">#{{ page.tag }}</span>
+  {% endif %}
+</nav>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -124,6 +124,8 @@
   <!-- ══════════ MAIN ══════════ -->
   <div class="main">
 
+    {% include breadcrumb.html %}
+
     <!-- Hero -->
     <section class="hero">
       <p class="hero-eyebrow">// categoria //</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -129,6 +129,8 @@
   <!-- ══════════ MAIN ══════════ -->
   <div class="main">
 
+    {% include breadcrumb.html %}
+
     <!-- Hero -->
     {% if page.image %}
     <header class="hero hero--with-image" style="background-image: url('{{ page.image | relative_url }}');">

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -123,6 +123,8 @@
   <!-- ══════════ MAIN ══════════ -->
   <div class="main">
 
+    {% include breadcrumb.html %}
+
     <section class="hero">
       <p class="hero-eyebrow">// tópico //</p>
       <h1 class="hero-title">{{ page.tag }}</h1>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -233,6 +233,20 @@ a { color: inherit; text-decoration: none; }
 .main { flex: 1; min-width: 0; display: flex; flex-direction: column; background: var(--stage-bg); }
 
 /* ─────────────────────────────────────
+   BREADCRUMB
+───────────────────────────────────── */
+.breadcrumb {
+  display: flex; align-items: center; flex-wrap: wrap; gap: .3rem .5rem;
+  padding: .55rem 2rem;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.62rem;
+  letter-spacing: .04em; color: var(--ink-muted);
+  border-bottom: 1px solid var(--border);
+}
+.breadcrumb a { color: var(--ink-muted); }
+.breadcrumb a:hover { color: var(--accent); }
+.breadcrumb [aria-current="page"] { color: var(--ink); }
+
+/* ─────────────────────────────────────
    HERO — index.html variant
    (uses .hero-title, .hero-desc, .hero-stats)
 ───────────────────────────────────── */


### PR DESCRIPTION
## 📑 Description
Introduce a breadcrumb navigation component to enhance the user experience by providing context and navigation aids on category, tag, and post pages. This change includes the addition of a new breadcrumb.html include file and its integration into the main content area of category.html, post.html, and tag.html layouts. CSS styles for the breadcrumb are also added to main.css to ensure consistent and appealing presentation.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a reusable breadcrumb navigation component and integrate it into key content layouts to improve contextual navigation across the site.

New Features:
- Introduce a breadcrumb include that renders hierarchical navigation for post, category, and tag pages.
- Add breadcrumb styling to the main stylesheet for consistent visual presentation.

Enhancements:
- Integrate the breadcrumb component into category, post, and tag layouts to surface navigation in the main content area.