### PR TITLE
refactor: extract footer into a separate include

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,16 @@
+    <footer class="site-footer">
+      <div class="site-footer-inner">
+        <span class="footer-brand">{{ site.title }}</span>
+        <ul class="footer-links">
+          {% if page.url != "/" %}
+            <li><a href="{{ site.baseurl }}/">← Todos os artigos</a></li>
+          {% endif %}
+          {% if page.url contains "/topicos/" %}
+            <li><a href="{{ site.baseurl }}/topicos/">← Todos os tópicos</a></li>
+          {% endif %}         
+          <li><a href="{{ site.baseurl }}/feed.xml">RSS</a></li>
+          <li><a href="{{ site.baseurl }}/sitemap.xml">Sitemap</a></li>
+        </ul>
+        <span class="footer-meta">© {{ 'now' | date: "%Y" }} · Jekyll + GitHub Pages</span>
+      </div>
+    </footer>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -79,17 +79,7 @@
 
     </div>
 
-    <!-- Footer -->
-    <footer class="site-footer">
-      <div class="site-footer-inner">
-        <span class="footer-brand">{{ site.title }}</span>
-        <ul class="footer-links">
-          <li><a href="{{ site.baseurl }}/">← Todos os artigos</a></li>
-          <li><a href="{{ site.baseurl }}/feed.xml">RSS</a></li>
-        </ul>
-        <span class="footer-meta">© {{ 'now' | date: "%Y" }} · Jekyll + GitHub Pages</span>
-      </div>
-    </footer>
+    {% include footer.html %}
 
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -201,17 +201,7 @@
 
     </div><!-- /.article-wrap -->
 
-    <!-- Footer -->
-    <footer class="site-footer">
-      <div class="site-footer-inner">
-        <span class="footer-brand">{{ site.title }}</span>
-        <ul class="footer-links">
-          <li><a href="{{ site.baseurl }}/">← Todos os artigos</a></li>
-          <li><a href="{{ site.baseurl }}/feed.xml">RSS</a></li>
-        </ul>
-        <span class="footer-meta">© {{ 'now' | date: "%Y" }} · Jekyll + GitHub Pages</span>
-      </div>
-    </footer>
+    {% include footer.html %}
 
   </div><!-- /.main -->
 

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -84,17 +84,7 @@
 
     </div>
 
-    <footer class="site-footer">
-      <div class="site-footer-inner">
-        <span class="footer-brand">{{ site.title }}</span>
-        <ul class="footer-links">
-          <li><a href="{{ site.baseurl }}/topicos/">← Todos os tópicos</a></li>
-          <li><a href="{{ site.baseurl }}/">Home</a></li>
-          <li><a href="{{ site.baseurl }}/feed.xml">RSS</a></li>
-        </ul>
-        <span class="footer-meta">© {{ 'now' | date: "%Y" }} · Jekyll + GitHub Pages</span>
-      </div>
-    </footer>
+    {% include footer.html %}
 
   </div>
 

--- a/busca.html
+++ b/busca.html
@@ -72,16 +72,7 @@ permalink: /busca/
 
     </div>
 
-    <footer class="site-footer">
-      <div class="site-footer-inner">
-        <span class="footer-brand">{{ site.title }}</span>
-        <ul class="footer-links">
-          <li><a href="{{ site.baseurl }}/">← Todos os artigos</a></li>
-          <li><a href="{{ site.baseurl }}/feed.xml">RSS</a></li>
-        </ul>
-        <span class="footer-meta">© {{ 'now' | date: "%Y" }} · Jekyll + GitHub Pages</span>
-      </div>
-    </footer>
+    {% include footer.html %}
 
   </div>
 

--- a/index.html
+++ b/index.html
@@ -252,16 +252,7 @@ pagination:
       {% endif %}
     </div>
 
-    <footer class="site-footer">
-      <div class="site-footer-inner">
-        <span class="footer-brand">{{ site.title }}</span>
-        <ul class="footer-links">
-          <li><a href="{{ site.baseurl }}/feed.xml">RSS</a></li>
-          <li><a href="{{ site.baseurl }}/sitemap.xml">Sitemap</a></li>
-        </ul>
-        <span class="footer-meta">© {{ 'now' | date: "%Y" }} · Jekyll + GitHub Pages</span>
-      </div>
-    </footer>
+    {% include footer.html %}
 
   </div>
 


### PR DESCRIPTION
## 📑 Description
Create a new `footer.html` partial to centralize the footer markup. Replace the duplicated footer HTML across different page layouts with a single include statement (`{% include footer.html %}`). This change improves maintainability by keeping the footer content consistent across all pages and making future updates to the footer easier.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Enhancements:
- Introduce a centralized footer.html include to standardize footer content and links across the site and simplify future maintenance.