### PR TITLE
refactor: use post-card.html for uniform post rendering

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,0 +1,27 @@
+            <article class="post-card{% if include.featured %} post-card--featured{% endif %}">
+              <a href="{{ include.post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
+                {% if include.post.image %}
+                  <img src="{{ include.post.image | relative_url }}" alt="{{ include.post.title }}">
+                {% else %}
+                  <div class="post-card-placeholder"><span>{{ include.post.title | slice: 0 }}</span></div>
+                {% endif %}
+              </a>
+              <div class="post-card-body">
+                {% if include.featured %}<span class="featured-badge">⭐ Destaque</span>{% endif %}
+                {% if include.post.categories.size > 0 %}
+                <div class="post-card-cats">
+                  {% for cat in include.post.categories limit: 2 %}<span class="cat-pill">{{ cat }}</span>{% endfor %}
+                </div>
+                {% endif %}
+                <h3><a href="{{ include.post.url | relative_url }}">{{ include.post.title }}</a></h3>
+                {% if include.post.description %}
+                <p class="post-card-excerpt">{{ include.post.description | truncate: 110 }}</p>
+                {% elsif include.post.excerpt %}
+                <p class="post-card-excerpt">{{ include.post.excerpt | strip_html | truncate: 110 }}</p>
+                {% endif %}
+                <div class="post-card-meta">
+                  <span>{{ include.post.date | date: "%d/%m/%Y" }}</span>
+                  {% if include.post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ include.post.reading_time }} min</span>{% endif %}
+                </div>
+              </div>
+            </article>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -46,32 +46,7 @@
 
         <div class="posts-grid">
           {% for post in paginator.posts %}
-          <article class="post-card">
-            <a href="{{ post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
-              {% if post.image %}
-                <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
-              {% else %}
-                <div class="post-card-placeholder"><span>{{ post.title | slice: 0 }}</span></div>
-              {% endif %}
-            </a>
-            <div class="post-card-body">
-              {% if post.categories.size > 0 %}
-              <div class="post-card-cats">
-                {% for cat in post.categories limit: 2 %}<span class="cat-pill">{{ cat }}</span>{% endfor %}
-              </div>
-              {% endif %}
-              <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-              {% if post.description %}
-              <p class="post-card-excerpt">{{ post.description | truncate: 110 }}</p>
-              {% elsif post.excerpt %}
-              <p class="post-card-excerpt">{{ post.excerpt | strip_html | truncate: 110 }}</p>
-              {% endif %}
-              <div class="post-card-meta">
-                <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
-              </div>
-            </div>
-          </article>
+          {% include post-card.html post=post %}
           {% endfor %}
         </div>
         {% include pagination.html %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -51,32 +51,7 @@
           </div>
           <div class="posts-grid">
             {% for post in tag_posts %}
-            <article class="post-card">
-              <a href="{{ post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
-                {% if post.image %}
-                  <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
-                {% else %}
-                  <div class="post-card-placeholder"><span>{{ post.title | slice: 0 }}</span></div>
-                {% endif %}
-              </a>
-              <div class="post-card-body">
-                {% if post.categories.size > 0 %}
-                <div class="post-card-cats">
-                  {% for cat in post.categories limit: 2 %}<span class="cat-pill">{{ cat }}</span>{% endfor %}
-                </div>
-                {% endif %}
-                <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-                {% if post.description %}
-                <p class="post-card-excerpt">{{ post.description | truncate: 110 }}</p>
-                {% elsif post.excerpt %}
-                <p class="post-card-excerpt">{{ post.excerpt | strip_html | truncate: 110 }}</p>
-                {% endif %}
-                <div class="post-card-meta">
-                  <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                  {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
-                </div>
-              </div>
-            </article>
+            {% include post-card.html post=post %}
             {% endfor %}
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -78,33 +78,7 @@ pagination:
           </div>
           <div class="posts-grid">
             {% for post in pinned %}
-            <article class="post-card post-card--featured">
-              <a href="{{ post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
-                {% if post.image %}
-                  <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
-                {% else %}
-                  <div class="post-card-placeholder"><span>{{ post.title | slice: 0 }}</span></div>
-                {% endif %}
-              </a>
-              <div class="post-card-body">
-                <span class="featured-badge">⭐ Destaque</span>
-                {% if post.categories.size > 0 %}
-                <div class="post-card-cats">
-                  {% for cat in post.categories limit: 2 %}<span class="cat-pill">{{ cat }}</span>{% endfor %}
-                </div>
-                {% endif %}
-                <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-                {% if post.description %}
-                <p class="post-card-excerpt">{{ post.description | truncate: 110 }}</p>
-                {% elsif post.excerpt %}
-                <p class="post-card-excerpt">{{ post.excerpt | strip_html | truncate: 110 }}</p>
-                {% endif %}
-                <div class="post-card-meta">
-                  <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                  {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
-                </div>
-              </div>
-            </article>
+            {% include post-card.html post=post featured=true %}
             {% endfor %}
           </div>
         </div>
@@ -117,32 +91,7 @@ pagination:
           </div>
           <div class="posts-grid">
             {% for post in regular_posts %}
-            <article class="post-card">
-              <a href="{{ post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
-                {% if post.image %}
-                  <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
-                {% else %}
-                  <div class="post-card-placeholder"><span>{{ post.title | slice: 0 }}</span></div>
-                {% endif %}
-              </a>
-              <div class="post-card-body">
-                {% if post.categories.size > 0 %}
-                <div class="post-card-cats">
-                  {% for cat in post.categories limit: 2 %}<span class="cat-pill">{{ cat }}</span>{% endfor %}
-                </div>
-                {% endif %}
-                <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-                {% if post.description %}
-                <p class="post-card-excerpt">{{ post.description | truncate: 110 }}</p>
-                {% elsif post.excerpt %}
-                <p class="post-card-excerpt">{{ post.excerpt | strip_html | truncate: 110 }}</p>
-                {% endif %}
-                <div class="post-card-meta">
-                  <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                  {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
-                </div>
-              </div>
-            </article>
+            {% include post-card.html post=post %}
             {% endfor %}
           </div>
           {% include pagination.html %}
@@ -200,32 +149,7 @@ pagination:
           </div>
           <div class="posts-grid">
             {% for post in other_posts %}
-            <article class="post-card">
-              <a href="{{ post.url | relative_url }}" class="post-card-image" tabindex="-1" aria-hidden="true">
-                {% if post.image %}
-                  <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
-                {% else %}
-                  <div class="post-card-placeholder"><span>{{ post.title | slice: 0 }}</span></div>
-                {% endif %}
-              </a>
-              <div class="post-card-body">
-                {% if post.categories.size > 0 %}
-                <div class="post-card-cats">
-                  {% for cat in post.categories limit: 2 %}<span class="cat-pill">{{ cat }}</span>{% endfor %}
-                </div>
-                {% endif %}
-                <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-                {% if post.description %}
-                <p class="post-card-excerpt">{{ post.description | truncate: 110 }}</p>
-                {% elsif post.excerpt %}
-                <p class="post-card-excerpt">{{ post.excerpt | strip_html | truncate: 110 }}</p>
-                {% endif %}
-                <div class="post-card-meta">
-                  <span>{{ post.date | date: "%d/%m/%Y" }}</span>
-                  {% if post.reading_time %}<span><i class="fa-regular fa-clock"></i> ~{{ post.reading_time }} min</span>{% endif %}
-                </div>
-              </div>
-            </article>
+            {% include post-card.html post=post %}
             {% endfor %}
           </div>
           {% include pagination.html %}


### PR DESCRIPTION
## 📑 Description
Introduce a new `_includes/post-card.html` to centralize the post card structure. Refactor category, tag, and index layouts to use the new include for consistent and maintainable code. This reduces repetition and ensures uniform styling and behavior across post listings. Featured post logic is retained through a parameter passed to the include.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Centralize post card rendering into a reusable include to ensure consistent presentation of posts across the index, category, and tag pages.

Enhancements:
- Introduce a new _includes/post-card.html partial that encapsulates the shared markup and logic for rendering post cards, including featured state handling.
- Refactor index, category, and tag layouts to use the new post card include for all post listings, reducing duplication and easing future maintenance.