### PR TITLE
refactor: move permissions block to deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -40,6 +35,10 @@ jobs:
         uses: actions/upload-pages-artifact@v5
 
   deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## 📑 Description
Relocate the permissions block from the root level to the deploy job to ensure proper access control during deployment. This change streamlines permissions management, making it clearer that these specific permissions are required only for the deployment process.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

CI:
- Move GitHub Actions permissions from workflow-level to the deploy job to limit access to the deployment step.