### PR TITLE
Fix XML escaping in RSS feed generation

### DIFF
--- a/.github/scripts/create_missing_pages.py
+++ b/.github/scripts/create_missing_pages.py
@@ -84,24 +84,23 @@ def feed_template(original: str, slug: str) -> str:
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\n'
         "  <channel>\n"
-        f'    <title>{{{{ site.title }}}} — {original}</title>\n'
-        f'    <description>Artigos sobre {original} em {{{{ site.title }}}}</description>\n'
+        f'    <title>{{{{ site.title }}}} — {original.replace("&", "&amp;")}</title>\n'
+        f'    <description>Artigos sobre {original.replace("&", "&amp;")} em {{{{ site.title }}}}</description>\n'
         f'    <link>{{{{ site.url }}}}{{{{ site.baseurl }}}}/categorias/{slug}/</link>\n'
         f'    <atom:link href="{{{{ site.url }}}}{{{{ site.baseurl }}}}/feed/{slug}.xml"'
         ' rel="self" type="application/rss+xml"/>\n'
         "    <language>pt-BR</language>\n"
-        "    {{% assign cat_posts = site.posts"
-        f' | where_exp: "p", "p.categories contains \'{original}\'"'
-        " | limit: 20 %}\n"
-        "    {{% for post in cat_posts %}}\n"
+        f'    {{% assign _cat = "{original}" %}}\n'
+        '    {% assign cat_posts = site.posts | where_exp: "p", "p.categories contains _cat" | limit: 20 %}\n'
+        "    {% for post in cat_posts %}\n"
         "    <item>\n"
-        "      <title>{{{{ post.title | xml_escape }}}}</title>\n"
-        "      <link>{{{{ post.url | absolute_url }}}}</link>\n"
-        '      <guid isPermaLink="true">{{{{ post.url | absolute_url }}}}</guid>\n'
-        "      <pubDate>{{{{ post.date | date_to_rfc822 }}}}</pubDate>\n"
-        "      <description>{{{{ post.description | xml_escape }}}}</description>\n"
+        "      <title>{{ post.title | xml_escape }}</title>\n"
+        "      <link>{{ post.url | absolute_url }}</link>\n"
+        '      <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>\n'
+        "      <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>\n"
+        "      <description>{{ post.description | xml_escape }}</description>\n"
         "    </item>\n"
-        "    {{% endfor %}}\n"
+        "    {% endfor %}\n"
         "  </channel>\n"
         "</rss>\n"
     )

--- a/.github/scripts/create_missing_pages.py
+++ b/.github/scripts/create_missing_pages.py
@@ -84,8 +84,8 @@ def feed_template(original: str, slug: str) -> str:
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\n'
         "  <channel>\n"
-        f'    <title>{{{{ site.title }}}} — {original.replace("&", "&amp;")}</title>\n'
-        f'    <description>Artigos sobre {original.replace("&", "&amp;")} em {{{{ site.title }}}}</description>\n'
+        f'    <title>{{{{ site.title | xml_escape }}}} — {original.replace("&", "&amp;")}</title>\n'
+        f'    <description>Artigos sobre {original.replace("&", "&amp;")} em {{{{ site.title | xml_escape }}}}</description>\n'
         f'    <link>{{{{ site.url }}}}{{{{ site.baseurl }}}}/categorias/{slug}/</link>\n'
         f'    <atom:link href="{{{{ site.url }}}}{{{{ site.baseurl }}}}/feed/{slug}.xml"'
         ' rel="self" type="application/rss+xml"/>\n'

--- a/.github/scripts/create_missing_pages.py
+++ b/.github/scripts/create_missing_pages.py
@@ -195,6 +195,9 @@ def create_pages(
             f"layout: {CATEGORY_LAYOUT}\n"
             f"category: {original}\n"
             f"permalink: {CATEGORY_PERMALINK.format(slug=slug)}\n"
+            f"pagination:\n"
+            f"  enabled: true\n"
+            f"  category: {original}\n"
             f"---\n",
             encoding='utf-8',
         )


### PR DESCRIPTION
## 📑 Description
Fix XML escaping in RSS feed generation

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Fix XML escaping and category filtering in generated RSS feeds for category pages.

Bug Fixes:
- Escape ampersands in RSS channel title and description derived from category names.
- Correct Liquid templates to use assign variables and filters safely for post titles, URLs, dates, and descriptions in RSS items.