### PR TITLE
chore: delay Python setup until needed

### DIFF
--- a/.github/workflows/auto-create-pages.yml
+++ b/.github/workflows/auto-create-pages.yml
@@ -3,8 +3,6 @@ name: Auto-create category and tag pages
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '_posts/**'
 
 permissions:
   contents: write
@@ -23,11 +21,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
       - name: Get changed post files
         id: changed
         run: |
@@ -41,10 +34,16 @@ jobs:
           echo "files=${CHANGED}" >> "$GITHUB_OUTPUT"
 
           if [ -z "$CHANGED" ]; then
-            echo "No post files changed."
+            echo "No post files changed — skipping page creation."
           else
             echo "Changed posts: $CHANGED"
           fi
+
+      - name: Set up Python
+        if: steps.changed.outputs.files != ''
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
 
       - name: Create missing category and tag pages
         if: steps.changed.outputs.files != ''
@@ -79,4 +78,4 @@ jobs:
 
       - name: No new pages needed
         if: steps.changed.outputs.files == '' || steps.create.outputs.created_count == '0'
-        run: echo "✅ All category and tag pages already exist."
+        run: echo "All category and tag pages already exist."


### PR DESCRIPTION
## 📑 Description
Reorder steps in the GitHub workflow to set up Python only if there are changed `_posts` files. This optimizes the workflow by skipping unnecessary setup, improving efficiency and reducing execution time when no posts are modified. Also, refine console output for clarity.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Reorder the auto-create pages GitHub workflow to only set up Python when relevant posts have changed and adjust messaging for clearer console output.

Enhancements:
- Refine workflow log messages to more clearly indicate when page creation is skipped or when all category and tag pages already exist.

CI:
- Conditionally set up Python in the auto-create pages workflow only when changed post files are detected and relax the pull_request path filter so the job can run more broadly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized automated page generation workflow to improve efficiency by running setup steps only when necessary and removing unnecessary execution filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->