### PR TITLE
feat: add new blog post on maximizing free tier VMs

### DIFF
--- a/_posts/2026-07-03-18-servicos-4-vms-1gb-free-tier.md
+++ b/_posts/2026-07-03-18-servicos-4-vms-1gb-free-tier.md
@@ -3,8 +3,9 @@ layout: post
 title: "18 serviços em 4 VMs de 1 GB: arquitetando no free tier sem sofrer"
 date: 2026-07-03 22:00:00 +0100
 categories: [infraestrutura]
-tags: [devops, linux, nginx, arquitetura, self-hosted, free-tier]
+tags: [devops, linux, nginx, arquitetura, self-hosted, free-tier, oracle-cloud, oci, ubuntu, php, dotnet, mariadb, redis, wireguard, hardening]
 lang: pt-BR
+reading_time: 9
 description: "Como distribuí quase vinte serviços PHP e .NET em quatro VMs gratuitas de 1 GB de RAM, com fila de mensagens, banco de dados, cache e hardening — sem estourar a memória."
 image: /assets/img/posts/diagrama-capa.svg
 ---

--- a/_posts/2026-07-03-18-servicos-4-vms-1gb-free-tier.md
+++ b/_posts/2026-07-03-18-servicos-4-vms-1gb-free-tier.md
@@ -1,0 +1,98 @@
+---
+layout: post
+title: "18 serviços em 4 VMs de 1 GB: arquitetando no free tier sem sofrer"
+date: 2026-07-03 22:00:00 +0100
+categories: [infraestrutura]
+tags: [devops, linux, nginx, arquitetura, self-hosted, free-tier]
+lang: pt-BR
+description: "Como distribuí quase vinte serviços PHP e .NET em quatro VMs gratuitas de 1 GB de RAM, com fila de mensagens, banco de dados, cache e hardening — sem estourar a memória."
+image: /assets/img/posts/diagrama-capa.svg
+---
+
+Todo desenvolvedor com projetos pessoais chega nessa encruzilhada: os serviços se multiplicam — APIs, bots, dashboards, workers — e a conta da nuvem não pode multiplicar junto. No meu caso, o inventário chegou a **18 serviços**, entre PHP e C#/.NET, e a plataforma escolhida foi a **Oracle Cloud Infrastructure (OCI)**, rodando em **quatro instâncias VM.Standard.E2.1.Micro** — o shape AMD do free tier, com 1/8 de OCPU (burstável) e 1 GB de RAM cada.
+
+Um gigabyte de RAM é pouco. Quatro gigabytes espalhados em quatro máquinas é menos ainda, porque cada uma paga o pedágio do sistema operacional. Este post documenta como organizei tudo: a distribuição de carga, as escolhas de middleware, a configuração de rede na OCI, o hardening antes do primeiro deploy e os ajustes de memória que fazem a diferença entre "funciona" e "o OOM killer derrubou o bot de trading às 3 da manhã".
+
+## O free tier da OCI em números
+
+Vale ser transparente sobre o que é gratuito de verdade. O **Always Free** da OCI inclui, em qualquer tenancy:
+
+- **Duas** instâncias `VM.Standard.E2.1.Micro` (AMD, 1/8 OCPU burstável, 1 GB de RAM cada);
+- Instâncias Ampere A1 (ARM): desde junho de 2026, o limite para tenancies Always Free caiu para o equivalente a **2 OCPUs e 12 GB de RAM** no total (eram 4 OCPUs / 24 GB — contas pagas ainda podem manter o teto antigo);
+- **200 GB** de block storage no total, incluindo os boot volumes (cada VM nasce com ~47–50 GB, então quatro VMs consomem praticamente toda a cota);
+- **20 GB** de Object Storage (compartilhados com o archive storage) e 10 TB/mês de egress;
+- VCN, gateways, security lists e um Network Load Balancer, tudo dentro do free tier.
+
+Repare no detalhe: o Always Free cobre **duas** E2.1.Micro. Como eu rodo quatro, a conta precisa estar no modo Pay As You Go — as duas primeiras continuam gratuitas para sempre, e as duas extras custam centavos por mês (o E2.1.Micro é o shape mais barato do catálogo). Se você quer ficar 100% no gratuito, a alternativa é trocar as quatro micro por **uma ou duas Ampere A1** — 12 GB de RAM em ARM acomodariam este stack inteiro com folga, ao custo de recompilar os binários .NET para `linux-arm64` e disputar a famosa loteria de capacidade ("out of capacity") das regiões populares.
+
+## O sistema operacional: quanto menos, melhor
+
+Recriei todas as VMs com a imagem **Canonical Ubuntu 24.04 Minimal** do catálogo da OCI. A imagem Minimal traz cerca de 30% menos pacotes e daemons que a padrão — e nesse cenário cada daemon ocioso é RAM que uma aplicação deixa de usar. Um detalhe que pega muita gente na hora de escolher a imagem: a variante `aarch64` é exclusiva das instâncias Ampere A1 (ARM). Nas E2.1.Micro, que são AMD x86_64, ela nem sequer inicializa.
+
+## Dividir por papel, não por serviço
+
+O erro clássico seria espalhar os serviços pelas máquinas até "caber". A abordagem que funcionou foi separar por **papel**: uma VM de borda, uma de dados e duas de aplicação — uma por runtime. Isso consolida os runtimes (um único pool PHP-FPM, uma única instalação do ASP.NET runtime), tira os dados da internet pública e dá a cada máquina um perfil de tuning coerente.
+
+<figure>
+  <img src="/assets/img/posts/free-tier-vms/diagrama-infraestrutura.svg" alt="Topologia da infraestrutura: VCN da OCI com sub-rede pública contendo a VM gateway e sub-rede privada com as VMs de dados, PHP e .NET" loading="lazy">
+  <figcaption>Topologia da VCN: só o gateway tem IP público. Todo o resto vive em sub-rede privada.</figcaption>
+</figure>
+
+Na OCI, isso se traduz numa **VCN 10.0.0.0/16** com duas sub-redes: a **pública (10.0.0.0/24)**, ligada a um Internet Gateway, onde vive apenas a vm1; e a **privada (10.0.1.0/24)**, sem IPs públicos, onde ficam vm2, vm3 e vm4. A sub-rede privada sai para a internet (atualizações de pacote, chamadas a APIs externas) através de um **NAT Gateway** — também incluído no free tier — sem jamais aceitar conexões de entrada vindas de fora.
+
+As security lists seguem o desenho: a sub-rede pública aceita apenas 443/TCP e 51820/UDP do mundo (mais 22/TCP restrito durante o bootstrap); a privada aceita tráfego apenas do CIDR da própria VCN. Uma dica de organização: para as regras por serviço (3306 para o MariaDB, 6379 para o Redis, 5672 para a fila), **Network Security Groups** são mais limpos que security lists — você anexa o NSG à VNIC de cada instância em vez de à sub-rede inteira.
+
+Sobre a VPN de administração: escolhi **WireGuard em vez de OpenVPN** sem hesitar. Roda no kernel, ocupa uns 4 MB, não tem pilha TLS para administrar e vira o meu plano de administração — SSH, o banco e qualquer painel interno escutam apenas na interface do túnel, nunca na internet.
+
+Uma exceção interessante na vm1: além do papel de borda, ela hospeda o **handler de webhooks** do meu bot de automação. É o único componente do bot que precisa aceitar tráfego público não solicitado, e o trabalho dele é trivial — validar a assinatura HMAC, publicar a mensagem na fila e devolver `202`. Com isso, a VM de aplicação .NET nunca precisa de ingresso público, e um pico de webhooks estoura na fila, não no worker.
+
+## Fila, cache e banco: o que entra e o que fica de fora
+
+Aqui as restrições de memória decidiram quase tudo sozinhas.
+
+**RabbitMQ ficou de fora.** A VM Erlang dele ocupa de 150 a 400 MB em repouso — inaceitável numa máquina de 1 GB que ainda precisa rodar MariaDB. A substituição foi o **LavinMQ**, que fala o mesmo protocolo AMQP 0.9.1 (ou seja: nenhum cliente muda) e fica na casa dos 30 a 100 MB. Se nem isso couber no seu cenário, uma fila gerenciada externa resolve com custo zero de RAM local.
+
+**etcd também ficou de fora**, por outro motivo: não há problema de consenso distribuído para resolver aqui. Configuração e segredos ficam num cofre próprio (um serviço leve de *configuration & secrets management* que roda na camada .NET), então o etcd seria redundância pura ocupando ~100 MB que não existem.
+
+**MariaDB e Redis entraram**, ambos na vm2, ambos com rédea curta: um banco por aplicação no MariaDB com `innodb_buffer_pool_size` reduzido, e Redis com `maxmemory` fixado e política `allkeys-lru` para cache e rate limiting.
+
+<figure>
+  <img src="/assets/img/posts/free-tier-vms/diagrama-servicos.svg" alt="Camadas lógicas: consumidores passam pelo edge Nginx e chegam às camadas PHP e .NET, que dependem de MariaDB, Redis e LavinMQ" loading="lazy">
+  <figcaption>A visão lógica: três origens de tráfego, um edge, dois runtimes, uma camada de dados compartilhada.</figcaption>
+</figure>
+
+O fluxo assíncrono que esse desenho esconde é justamente o mais valioso: webhook chega no handler (vm1) → mensagem publicada na fila (vm2) → worker de automação (vm4) consome no ritmo que 1/8 de OCPU permite. O cofre de configurações fecha o ciclo: cada serviço busca suas connection strings e segredos nele ao subir, então as credenciais do banco existem em exatamente um lugar.
+
+## Quem roda onde
+
+<figure>
+  <img src="/assets/img/posts/free-tier-vms/diagrama-distribuicao.svg" alt="Mapa dos serviços por VM: gateway com Nginx e handler de webhooks; VM .NET com worker, cofre, bot de trading e APIs financeiras; VM PHP com ingestão de logs e APIs de dados; VM de dados com MariaDB, Redis e LavinMQ" loading="lazy">
+  <figcaption>O mapa completo: cada serviço na máquina do seu runtime.</figcaption>
+</figure>
+
+A camada PHP é a mais tranquila: com PHP-FPM em `pm = ondemand` e `pm.max_children` baixo, aplicações ociosas custam praticamente zero — é por isso que uma única VM hospeda meia dúzia de APIs (ingestão de logs, APIs públicas de dados, utilitários, câmbio) sem drama.
+
+A camada .NET é o ponto de pressão. Rodar seis ou mais processos Kestrel em 1 GB só funciona com tuning deliberado: `ServerGarbageCollection=false` (GC de workstation), `InvariantGlobalization=true`, `DOTNET_GCHeapHardLimitPercent` por serviço e **um runtime compartilhado** (publicação framework-dependent) em vez de binários self-contained, cada um carregando sua cópia do runtime. Com isso, cada API fica entre 70 e 100 MB. O bot de trading ganha proteção prioritária via systemd (`MemoryLow=`), porque é o único serviço em que um OOM kill custa dinheiro de verdade.
+
+E se ainda assim apertar? A válvula de escape é o gateway: depois de Nginx, WireGuard e o handler, sobram uns 700 MB livres na vm1 — as duas APIs mais leves podem migrar para lá.
+
+## Hardening antes de qualquer deploy
+
+A ordem importa: rede e SSH primeiro, firewall depois, serviços por último. O checklist que segui em cada VM recém-criada:
+
+1. **Security lists e NSGs na OCI** — a sub-rede pública só aceita 443/TCP e 51820/UDP; a privada só aceita tráfego do CIDR da VCN. Lembrando que na OCI o firewall tem **duas camadas** (a security list/NSG no plano de rede e o firewall dentro do host) — a porta só está aberta quando as duas concordam.
+2. **SSH endurecido** — usuário próprio com chave, `PasswordAuthentication no`, `PermitRootLogin no`, `AllowUsers`, `MaxAuthTries 3`. Nas VMs privadas, o sshd escuta só na interface interna.
+3. **Um dono para o firewall** — as imagens Ubuntu da OCI vêm com regras iptables persistentes pré-instaladas em `/etc/iptables/rules.v4` que rejeitam tráfego silenciosamente, brigando com o UFW. Escolha um dono (eu fiquei com o UFW), limpe as regras herdadas e configure do zero. Metade dos mistérios de "porta aberta no console da OCI mas connection refused" nasce exatamente aqui.
+4. **UFW** — default deny na entrada; cada VM libera apenas as portas dos seus serviços e apenas para os CIDRs da VCN e do WireGuard. 3306 e 6379 jamais saem da rede privada.
+5. **Fail2Ban só no gateway** — jails de `sshd` e Nginx. Nas VMs privadas ele é quase inútil (nada público chega lá) e a RAM economizada vale mais.
+6. **Swap + zram — não pule esta** — 2 GB de swapfile com `vm.swappiness=10`, mais zram comprimido. Em VMs de 1 GB, é a diferença entre um momento lento e um serviço morto. Complementa com `MemoryMax=` e `Restart=always` nas units do systemd.
+7. **Nginx + Certbot no gateway** — um `server` block por domínio, cada um com `proxy_pass` para o upstream na sub-rede privada, HTTP/2, `limit_req` nos endpoints públicos. Sobre painéis de administração do Nginx: minha recomendação é não instalar — com os configs versionados em git e `nginx -t && systemctl reload nginx`, você perde pouco e evita mais um daemon exposto na máquina mais visada.
+8. **Rotina** — `unattended-upgrades` (só segurança), `chrony`, hostnames descritivos e backup noturno do MariaDB para o **OCI Object Storage** (os 20 GB do free tier dão de sobra para dumps comprimidos) via `mariadb-dump` + `rclone`.
+
+## O que ficou de lição
+
+Arquitetar para 1 GB de RAM é um exercício ótimo de disciplina. Cada escolha de middleware vira uma pergunta de orçamento ("esses 200 MB compram o quê?"), e a resposta quase sempre aponta para a opção mais simples: WireGuard em vez de OpenVPN, LavinMQ em vez de RabbitMQ, nenhum etcd, nenhum painel que um `git diff` substitui.
+
+A separação por papel — borda, dados, PHP, .NET — foi o que fez o conjunto caber. E o subproduto inesperado é que a topologia final é mais segura do que a versão "cada serviço na sua VM com IP público" jamais seria: uma única porta de entrada, dados isolados, administração por VPN, e a sub-rede privada saindo para o mundo apenas pelo NAT Gateway.
+
+Se você está montando algo parecido no free tier da OCI, espero que o mapa acima economize algumas madrugadas. E se o OOM killer visitar você mesmo assim — bem-vindo ao clube, o swap manda lembranças.

--- a/assets/img/posts/diagrama-capa.svg
+++ b/assets/img/posts/diagrama-capa.svg
@@ -1,0 +1,101 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" role="img">
+<title>Capa do post</title>
+<desc>Ilustracao abstrata animada: um no central distribui fluxo para tres nos abaixo, com particulas em movimento sobre fundo claro.</desc>
+<style>
+@keyframes dash { to { stroke-dashoffset: -64; } }
+@keyframes floaty { from { transform: translateY(0px); } to { transform: translateY(-8px); } }
+@keyframes drift1 { from { transform: translate(0,0); } to { transform: translate(30px,20px); } }
+@keyframes drift2 { from { transform: translate(0,0); } to { transform: translate(-25px,-15px); } }
+@keyframes pulse { 0% { r: 62; opacity: .45; } 100% { r: 105; opacity: 0; } }
+@keyframes drop { 0% { transform: translateY(0); opacity: 0; } 15% { opacity: .9; } 80% { opacity: .9; } 100% { transform: translateY(78px); opacity: 0; } }
+.flow { stroke-dasharray: 6 10; animation: dash 1.5s linear infinite; }
+.card { transform-box: fill-box; transform-origin: center; animation: floaty 5s ease-in-out infinite alternate; }
+.card.d1 { animation-delay: -1.2s; }
+.card.d2 { animation-delay: -2.6s; }
+.card.d3 { animation-delay: -3.8s; }
+.blob1 { transform-box: fill-box; transform-origin: center; animation: drift1 9s ease-in-out infinite alternate; }
+.blob2 { transform-box: fill-box; transform-origin: center; animation: drift2 11s ease-in-out infinite alternate; }
+.ring { animation: pulse 2.6s ease-out infinite; }
+.ring.r2 { animation-delay: 1.3s; }
+.req { animation: drop 2.4s ease-in infinite; }
+.req.q2 { animation-delay: .8s; }
+.req.q3 { animation-delay: 1.6s; }
+@media (prefers-reduced-motion: reduce) {
+  .flow, .card, .blob1, .blob2, .ring, .req { animation: none; }
+  .ring { opacity: 0; }
+}
+</style>
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0%" stop-color="#F8F5FA"/>
+    <stop offset="55%" stop-color="#FDFCFE"/>
+    <stop offset="100%" stop-color="#F4F8EC"/>
+  </linearGradient>
+  <pattern id="dots" width="46" height="46" patternUnits="userSpaceOnUse">
+    <circle cx="4" cy="4" r="2" fill="#79378B" opacity="0.07"/>
+  </pattern>
+  <filter id="soft" x="-40%" y="-40%" width="180%" height="180%">
+    <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#5e2b6c" flood-opacity="0.14"/>
+  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="55"/></filter>
+</defs>
+
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dots)"/>
+<circle class="blob1" cx="1040" cy="90" r="190" fill="#93CD3F" opacity="0.14" filter="url(#blur)"/>
+<circle class="blob2" cx="140" cy="540" r="220" fill="#79378B" opacity="0.12" filter="url(#blur)"/>
+
+<path id="p1" d="M 600 240 C 600 320, 300 330, 300 400" fill="none" class="flow" stroke="#79378B" stroke-width="2" opacity="0.35"/>
+<path id="p2" d="M 600 240 C 600 300, 600 350, 600 420" fill="none" class="flow" stroke="#79378B" stroke-width="2" opacity="0.35"/>
+<path id="p3" d="M 600 240 C 600 320, 900 330, 900 400" fill="none" class="flow" stroke="#79378B" stroke-width="2" opacity="0.35"/>
+
+<circle r="6" fill="#93CD3F">
+  <animateMotion dur="3.2s" repeatCount="indefinite" path="M 600 240 C 600 320, 300 330, 300 400"/>
+</circle>
+<circle r="5" fill="#79378B">
+  <animateMotion dur="2.6s" begin="0.6s" repeatCount="indefinite" path="M 600 240 C 600 300, 600 350, 600 420"/>
+</circle>
+<circle r="6" fill="#93CD3F">
+  <animateMotion dur="3.4s" begin="1.1s" repeatCount="indefinite" path="M 600 240 C 600 320, 900 330, 900 400"/>
+</circle>
+<circle r="4" fill="#79378B" opacity="0.7">
+  <animateMotion dur="3.2s" begin="1.6s" repeatCount="indefinite" path="M 600 240 C 600 320, 300 330, 300 400"/>
+</circle>
+<circle r="4" fill="#93CD3F" opacity="0.8">
+  <animateMotion dur="2.6s" begin="1.9s" repeatCount="indefinite" path="M 600 240 C 600 300, 600 350, 600 420"/>
+</circle>
+<circle r="4" fill="#79378B" opacity="0.7">
+  <animateMotion dur="3.4s" begin="2.3s" repeatCount="indefinite" path="M 600 240 C 600 320, 900 330, 900 400"/>
+</circle>
+
+<circle class="ring" cx="600" cy="180" r="62" fill="none" stroke="#93CD3F" stroke-width="2"/>
+<circle class="ring r2" cx="600" cy="180" r="62" fill="none" stroke="#79378B" stroke-width="2"/>
+
+<g class="req"><rect x="576" y="16" width="10" height="10" rx="3" fill="#79378B" opacity="0.8"/></g>
+<g class="req q2"><rect x="596" y="10" width="10" height="10" rx="3" fill="#93CD3F"/></g>
+<g class="req q3"><rect x="616" y="20" width="10" height="10" rx="3" fill="#79378B" opacity="0.8"/></g>
+
+<g class="card" filter="url(#soft)">
+  <rect x="538" y="118" width="124" height="124" rx="30" fill="#FFFFFF" stroke="#93CD3F" stroke-width="2.5"/>
+  <circle cx="600" cy="180" r="26" fill="#93CD3F"/>
+  <circle cx="600" cy="180" r="11" fill="#FFFFFF"/>
+</g>
+
+<g class="card d1" filter="url(#soft)">
+  <rect x="248" y="398" width="104" height="104" rx="26" fill="#FFFFFF" stroke="#79378B" stroke-width="2"/>
+  <rect x="272" y="432" width="56" height="10" rx="5" fill="#79378B" opacity="0.85"/>
+  <rect x="272" y="454" width="38" height="10" rx="5" fill="#93CD3F"/>
+</g>
+
+<g class="card d2" filter="url(#soft)">
+  <rect x="548" y="418" width="104" height="104" rx="26" fill="#FFFFFF" stroke="#79378B" stroke-width="2"/>
+  <rect x="572" y="452" width="56" height="10" rx="5" fill="#79378B" opacity="0.85"/>
+  <rect x="572" y="474" width="38" height="10" rx="5" fill="#93CD3F"/>
+</g>
+
+<g class="card d3" filter="url(#soft)">
+  <rect x="848" y="398" width="104" height="104" rx="26" fill="#FFFFFF" stroke="#79378B" stroke-width="2"/>
+  <rect x="872" y="432" width="56" height="10" rx="5" fill="#79378B" opacity="0.85"/>
+  <rect x="872" y="454" width="38" height="10" rx="5" fill="#93CD3F"/>
+</g>
+</svg>

--- a/assets/img/posts/free-tier-vms/diagrama-distribuicao.svg
+++ b/assets/img/posts/free-tier-vms/diagrama-distribuicao.svg
@@ -1,0 +1,46 @@
+<svg width="100%" viewBox="0 0 680 450" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>Distribuição dos serviços entre as VMs</title>
+<desc>Quatro caixas de VM mostrando quais servicos rodam em cada uma: gateway, apps .NET, apps PHP e dados.</desc>
+<style>
+.th{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;font-size:14px;font-weight:500}
+.ts{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;font-size:12px;font-weight:400}
+</style>
+<defs><marker id="arrow3" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="#5F5E5A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+<g>
+  <rect x="50" y="40" width="280" height="150" rx="12" fill="#EFF7E2" stroke="#76a432" stroke-width="0.5"/>
+  <text class="th" x="70" y="66" fill="#3f5c15">vm1 — gateway (pública)</text>
+  <text class="ts" x="70" y="94" fill="#4a6b1e">Nginx TLS + proxy reverso</text>
+  <text class="ts" x="70" y="114" fill="#4a6b1e">WireGuard (acesso admin)</text>
+  <text class="ts" x="70" y="134" fill="#4a6b1e">Certbot, Fail2Ban, UFW</text>
+  <text class="ts" x="70" y="154" fill="#4a6b1e">Handler de webhooks</text>
+</g>
+<g>
+  <rect x="350" y="40" width="280" height="190" rx="12" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="370" y="66" fill="#5e2b6c">vm4 — apps .NET (privada)</text>
+  <text class="ts" x="370" y="94" fill="#79378B">Worker de automação (fila)</text>
+  <text class="ts" x="370" y="114" fill="#79378B">API de gestão do bot</text>
+  <text class="ts" x="370" y="134" fill="#79378B">Cofre de config e segredos</text>
+  <text class="ts" x="370" y="154" fill="#79378B">API de alertas e notificações</text>
+  <text class="ts" x="370" y="174" fill="#79378B">Bot de trading (cripto)</text>
+  <text class="ts" x="370" y="194" fill="#79378B">APIs financeiras (cotações, FX)</text>
+</g>
+<g>
+  <rect x="50" y="250" width="280" height="170" rx="12" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="70" y="276" fill="#5e2b6c">vm3 — apps PHP (privada)</text>
+  <text class="ts" x="70" y="304" fill="#79378B">Ingestão de logs + dashboard</text>
+  <text class="ts" x="70" y="324" fill="#79378B">APIs utilitárias internas</text>
+  <text class="ts" x="70" y="344" fill="#79378B">APIs públicas de dados</text>
+  <text class="ts" x="70" y="364" fill="#79378B">APIs de câmbio e moedas</text>
+</g>
+<g>
+  <rect x="350" y="290" width="280" height="130" rx="12" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text class="th" x="370" y="316" fill="#712B13">vm2 — dados (privada)</text>
+  <text class="ts" x="370" y="344" fill="#993C1D">MariaDB (bancos das apps)</text>
+  <text class="ts" x="370" y="364" fill="#993C1D">Redis (cache, rate limits)</text>
+  <text class="ts" x="370" y="384" fill="#993C1D">LavinMQ (fila de webhooks)</text>
+</g>
+<line x1="330" y1="115" x2="348" y2="115" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow3)"/>
+<line x1="190" y1="190" x2="190" y2="248" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow3)"/>
+<line x1="490" y1="230" x2="490" y2="288" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow3)"/>
+<line x1="330" y1="355" x2="348" y2="355" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow3)"/>
+</svg>

--- a/assets/img/posts/free-tier-vms/diagrama-infraestrutura.svg
+++ b/assets/img/posts/free-tier-vms/diagrama-infraestrutura.svg
@@ -1,0 +1,52 @@
+<svg width="100%" viewBox="0 0 680 470" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>Topologia da infraestrutura</title>
+<desc>Uma rede virtual com sub-rede publica (VM gateway) e sub-rede privada (VMs de dados, PHP e .NET). Trafego da internet e do admin entra pelo gateway.</desc>
+<style>
+.th{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;font-size:14px;font-weight:500}
+.ts{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;font-size:12px;font-weight:400}
+</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="#5F5E5A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+<g>
+  <rect x="140" y="40" width="140" height="44" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text class="th" x="210" y="62" text-anchor="middle" dominant-baseline="central" fill="#444441">Internet</text>
+</g>
+<g>
+  <rect x="400" y="40" width="140" height="44" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text class="th" x="470" y="62" text-anchor="middle" dominant-baseline="central" fill="#444441">Você (admin)</text>
+</g>
+<line x1="210" y1="84" x2="210" y2="163" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+<text class="ts" x="220" y="112" fill="#5F5E5A">HTTPS 443</text>
+<line x1="470" y1="84" x2="470" y2="163" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+<text class="ts" x="480" y="112" fill="#5F5E5A">WireGuard UDP 51820</text>
+<rect x="40" y="125" width="600" height="320" rx="16" fill="none" stroke="#888780" stroke-width="0.75" stroke-dasharray="6 4"/>
+<text class="th" x="56" y="147" fill="#444441">OCI VCN — 10.0.0.0/16</text>
+<g>
+  <rect x="70" y="165" width="540" height="100" rx="12" fill="#EFF7E2" stroke="#76a432" stroke-width="0.5"/>
+  <text class="th" x="90" y="190" fill="#3f5c15">Sub-rede pública — 10.0.0.0/24</text>
+</g>
+<g>
+  <rect x="200" y="203" width="280" height="50" rx="8" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="340" y="222" text-anchor="middle" dominant-baseline="central" fill="#5e2b6c">vm1 — gateway</text>
+  <text class="ts" x="340" y="240" text-anchor="middle" dominant-baseline="central" fill="#79378B">Nginx TLS, WireGuard, Certbot</text>
+</g>
+<line x1="340" y1="253" x2="340" y2="293" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+<g>
+  <rect x="70" y="295" width="540" height="110" rx="12" fill="#F1EFE8" stroke="#888780" stroke-width="0.5"/>
+  <text class="th" x="90" y="320" fill="#444441">Sub-rede privada — 10.0.1.0/24, sem IPs públicos</text>
+</g>
+<g>
+  <rect x="90" y="335" width="150" height="56" rx="8" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="165" y="353" text-anchor="middle" dominant-baseline="central" fill="#5e2b6c">vm2 — dados</text>
+  <text class="ts" x="165" y="373" text-anchor="middle" dominant-baseline="central" fill="#79378B">BD, cache, fila</text>
+</g>
+<g>
+  <rect x="260" y="335" width="150" height="56" rx="8" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="335" y="353" text-anchor="middle" dominant-baseline="central" fill="#5e2b6c">vm3 — apps PHP</text>
+  <text class="ts" x="335" y="373" text-anchor="middle" dominant-baseline="central" fill="#79378B">PHP-FPM + daemons</text>
+</g>
+<g>
+  <rect x="430" y="335" width="150" height="56" rx="8" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="505" y="353" text-anchor="middle" dominant-baseline="central" fill="#5e2b6c">vm4 — apps .NET</text>
+  <text class="ts" x="505" y="373" text-anchor="middle" dominant-baseline="central" fill="#79378B">serviços Kestrel</text>
+</g>
+</svg>

--- a/assets/img/posts/free-tier-vms/diagrama-servicos.svg
+++ b/assets/img/posts/free-tier-vms/diagrama-servicos.svg
@@ -1,0 +1,59 @@
+<svg width="100%" viewBox="0 0 680 430" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>Camadas lógicas dos serviços</title>
+<desc>Consumidores no topo enviam trafego pelo edge Nginx para as camadas PHP e .NET, que dependem da camada de dados com MariaDB, Redis e LavinMQ.</desc>
+<style>
+.th{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;font-size:14px;font-weight:500}
+.ts{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;font-size:12px;font-weight:400}
+</style>
+<defs><marker id="arrow2" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="#5F5E5A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+<g>
+  <rect x="60" y="40" width="170" height="44" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text class="th" x="145" y="62" text-anchor="middle" dominant-baseline="central" fill="#444441">Webhooks (Git)</text>
+</g>
+<g>
+  <rect x="255" y="40" width="170" height="44" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text class="th" x="340" y="62" text-anchor="middle" dominant-baseline="central" fill="#444441">Portal e usuários</text>
+</g>
+<g>
+  <rect x="450" y="40" width="170" height="44" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text class="th" x="535" y="62" text-anchor="middle" dominant-baseline="central" fill="#444441">Clientes de API</text>
+</g>
+<line x1="145" y1="84" x2="300" y2="122" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<line x1="340" y1="84" x2="340" y2="122" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<line x1="535" y1="84" x2="380" y2="122" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<g>
+  <rect x="240" y="124" width="200" height="44" rx="8" fill="#EFF7E2" stroke="#76a432" stroke-width="0.5"/>
+  <text class="th" x="340" y="146" text-anchor="middle" dominant-baseline="central" fill="#3f5c15">Nginx edge (vm1)</text>
+</g>
+<line x1="310" y1="168" x2="200" y2="206" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<line x1="370" y1="168" x2="480" y2="206" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<g>
+  <rect x="90" y="208" width="220" height="56" rx="8" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="200" y="226" text-anchor="middle" dominant-baseline="central" fill="#5e2b6c">Camada PHP (vm3)</text>
+  <text class="ts" x="200" y="246" text-anchor="middle" dominant-baseline="central" fill="#79378B">logs, APIs de dados</text>
+</g>
+<g>
+  <rect x="370" y="208" width="220" height="56" rx="8" fill="#F3EAF6" stroke="#79378B" stroke-width="0.5"/>
+  <text class="th" x="480" y="226" text-anchor="middle" dominant-baseline="central" fill="#5e2b6c">Camada .NET (vm4)</text>
+  <text class="ts" x="480" y="246" text-anchor="middle" dominant-baseline="central" fill="#79378B">bots e APIs financeiras</text>
+</g>
+<line x1="200" y1="264" x2="200" y2="302" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<line x1="480" y1="264" x2="480" y2="302" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow2)"/>
+<rect x="90" y="304" width="500" height="100" rx="12" fill="none" stroke="#888780" stroke-width="0.75" stroke-dasharray="6 4"/>
+<text class="th" x="110" y="326" fill="#444441">Camada de dados (vm2)</text>
+<g>
+  <rect x="110" y="340" width="140" height="48" rx="8" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text class="th" x="180" y="358" text-anchor="middle" dominant-baseline="central" fill="#712B13">MariaDB</text>
+  <text class="ts" x="180" y="376" text-anchor="middle" dominant-baseline="central" fill="#993C1D">um BD por app</text>
+</g>
+<g>
+  <rect x="270" y="340" width="140" height="48" rx="8" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text class="th" x="340" y="358" text-anchor="middle" dominant-baseline="central" fill="#712B13">Redis</text>
+  <text class="ts" x="340" y="376" text-anchor="middle" dominant-baseline="central" fill="#993C1D">cache e limites</text>
+</g>
+<g>
+  <rect x="430" y="340" width="140" height="48" rx="8" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text class="th" x="500" y="358" text-anchor="middle" dominant-baseline="central" fill="#712B13">LavinMQ</text>
+  <text class="ts" x="500" y="376" text-anchor="middle" dominant-baseline="central" fill="#993C1D">fila AMQP</text>
+</g>
+</svg>

--- a/topicos/hardening.md
+++ b/topicos/hardening.md
@@ -1,0 +1,5 @@
+---
+layout: tag
+tag: hardening
+permalink: /topicos/hardening/
+---

--- a/topicos/oracle-cloud.md
+++ b/topicos/oracle-cloud.md
@@ -1,0 +1,5 @@
+---
+layout: tag
+tag: oracle-cloud
+permalink: /topicos/oracle-cloud/
+---

--- a/topicos/self-hosted.md
+++ b/topicos/self-hosted.md
@@ -1,0 +1,5 @@
+---
+layout: tag
+tag: self-hosted
+permalink: /topicos/self-hosted/
+---


### PR DESCRIPTION
## 📑 Description
Introduce a detailed article explaining how to deploy 18 services across four 1GB VMs using Oracle Cloud Infrastructure's free tier effectively. The post outlines strategies for managing a low-resource environment, such as using specific software and configurations to optimize memory usage. Key decisions include organizing VMs by function, using LavinMQ over RabbitMQ due to lower memory demands, and securing the infrastructure with WireGuard and strategic firewall settings. This post, written in Portuguese, provides insights and diagrammatic illustrations for readers seeking to optimize cloud resources cost-effectively.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a new Portuguese blog post detailing how to architect and harden an 18-service stack on four 1GB Oracle Cloud free-tier VMs, including diagrams of infrastructure, service distribution, and data flow.

New Features:
- Introduce a new blog post documenting a reference architecture for consolidating 18 services across four 1GB Oracle Cloud free-tier VMs.
- Add new architecture diagrams illustrating network topology, service distribution across VMs, and interactions between edge, runtimes, and data services.

Documentation:
- Add a long-form Portuguese article describing strategies for running PHP and .NET services efficiently on Oracle Cloud free-tier VMs with tight memory constraints, including networking, security, and operational practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Portuguese blog post about running multiple PHP and .NET services on OCI free tier with a 4-VM, 1GB setup.
  * Added a dedicated topic page for the “self-hosted” tag with proper site navigation and linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->