### PR TITLE
docs: expand LEGO collection post with detailed set info

### DIFF
--- a/_posts/2023-01-22-my-lego-creator-collection.md
+++ b/_posts/2023-01-22-my-lego-creator-collection.md
@@ -8,7 +8,7 @@ categories: [Hobbies]
 subcategories:
   - "Hobbies/LEGO"
 tags: [lego, colecao, hobbies, lego-creator, creator-expert]
-reading_time: 1
+reading_time: 3
 image: /assets/img/posts/lego-10197-1.jpg
 gallery: true
 ---
@@ -42,3 +42,63 @@ gallery: true
     <img src="{{ site.baseurl }}/assets/img/posts/post-Lego-5.jpg" alt="LEGO Creator Expert collection — photo 5">
   </a>
 </div>
+
+<div class="divider">· · ·</div>
+
+## The sets
+
+All six are **LEGO Creator Expert / Modular Buildings**, displayed as a single connected street.
+
+<table class="compare-table">
+  <thead>
+    <tr><th>#</th><th>Set</th><th>Set no.</th><th>Year</th><th>Pieces</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>🏦 1</td><td>Brick Bank</td><td>10251</td><td>2016</td><td>2,380</td></tr>
+    <tr><td>🏙️ 2</td><td>Assembly Square</td><td>10255</td><td>2017</td><td>4,002</td></tr>
+    <tr><td>🚒 3</td><td>Fire Brigade</td><td>10197</td><td>2009</td><td>2,231</td></tr>
+    <tr><td>👮 4</td><td>Police Station</td><td>10278</td><td>2021</td><td>2,923</td></tr>
+    <tr><td>📚 5</td><td>Bookshop</td><td>10270</td><td>2020</td><td>2,504</td></tr>
+    <tr><td>⛽ 6</td><td>Corner Garage</td><td>10264</td><td>2019</td><td>2,569</td></tr>
+  </tbody>
+</table>
+
+### 🏦 Brick Bank — 10251
+
+The building on the far left. Easy to spot by the façade: large arched windows, ornate trim and a central balcony. The 2,380-piece set includes the bank floor, a manager's office, a secretary's office and a hidden laundromat.
+
+[LEGO.com](https://www.lego.com/en-us/search?q=10251){:target="_blank"} · [Brickset](https://brickset.com/sets/10251-1){:target="_blank"} · [BrickLink](https://www.bricklink.com/v2/catalog/catalogitem.page?S=10251-1){:target="_blank"}
+
+### 🏙️ Assembly Square — 10255
+
+The large block of façades to the left of the Fire Brigade. It's easy to mistake for several separate buildings because the 10255 is deliberately made of connected structures. Its 4,002 pieces make up a bakery, a florist, a café, a music shop, a photo studio, a dental practice and a dance studio. It's the 10th-anniversary Modular Building.
+
+[LEGO.com](https://www.lego.com/en-us/search?q=10255){:target="_blank"} · [Brickset](https://brickset.com/sets/10255-1){:target="_blank"} · [BrickLink](https://www.bricklink.com/v2/catalog/catalogitem.page?S=10255-1){:target="_blank"}
+
+### 🚒 Fire Brigade — 10197
+
+The central building with **1932** on the façade. One of the first large Modular Buildings, released in 2009 — the oldest set in the collection, at 2,231 pieces.
+
+[LEGO.com](https://www.lego.com/en-us/search?q=10197){:target="_blank"} · [Brickset](https://brickset.com/sets/10197-1){:target="_blank"} · [BrickLink](https://www.bricklink.com/v2/catalog/catalogitem.page?S=10197-1){:target="_blank"}
+
+### 👮 Police Station — 10278
+
+The tall beige/grey building to the right of the Fire Brigade. The 10278 has 2,923 pieces across three floors, with the station, a holding cell, an interrogation room, a donut shop and a newsstand.
+
+[LEGO.com](https://www.lego.com/en-us/search?q=10278){:target="_blank"} · [Brickset](https://brickset.com/sets/10278-1){:target="_blank"} · [BrickLink](https://www.bricklink.com/v2/catalog/catalogitem.page?S=10278-1){:target="_blank"}
+
+### 📚 Bookshop — 10270
+
+Another one that isn't a single building: the 10270 is the three-storey bookshop **plus** the adjoining townhouse. 2,504 pieces total.
+
+[LEGO.com](https://www.lego.com/en-us/search?q=10270){:target="_blank"} · [Brickset](https://brickset.com/sets/10270-1){:target="_blank"} · [BrickLink](https://www.bricklink.com/v2/catalog/catalogitem.page?S=10270-1){:target="_blank"}
+
+### ⛽ Corner Garage — 10264
+
+On the far right. The garage takes the ground floor, with a vet clinic on the middle floor and an apartment on top. 2,569 pieces.
+
+[LEGO.com](https://www.lego.com/en-us/search?q=10264){:target="_blank"} · [Brickset](https://brickset.com/sets/10264-1){:target="_blank"} · [BrickLink](https://www.bricklink.com/v2/catalog/catalogitem.page?S=10264-1){:target="_blank"}
+
+### The street, left to right
+
+🏦 Brick Bank → 🏙️ Assembly Square → 🚒 Fire Brigade → 👮 Police Station → 📚 Bookshop → ⛽ Corner Garage


### PR DESCRIPTION
## 📑 Description
Add detailed descriptions for each LEGO Creator Expert set in the collection, enhancing the post with historical context and links to official and community resources. This helps enthusiasts and collectors to gain deeper insights and easily find more information about each set. Additionally, increase reading time to 3 minutes to reflect the updates.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Enrich the LEGO Creator Expert collection post with detailed information and references for each building.

Enhancements:
- Expand the LEGO Creator Expert collection post with a set overview, individual descriptions, historical context, and resource links for all six buildings.

Documentation:
- Increase the post’s estimated reading time to reflect the expanded content.