### PR TITLE
content: expand Malta post with cost charts and details

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -224,6 +224,8 @@
   slug: critical-skills
 - name: critical-skills-permit
   slug: critical-skills-permit
+- name: crystal-lagoon
+  slug: crystal-lagoon
 - name: csharp
   slug: csharp
   redirect_from:

--- a/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
+++ b/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
@@ -225,7 +225,7 @@ Isso teve efeito prático real no roteiro: encontrar-se implicava 20 a 30 minuto
 
 <div class="callout callout-warn">
   <div class="callout-label">★ Nota sobre o Dia 4 — o passeio que virou pó</div>
-  Eu tinha um passeio de barco comprado pelo <strong>GetYourGuide por € 26</strong>, saindo de San Pawl il-Baħar às 09h00 e voltando às 14h30. Dormimos demais e perdemos. O <strong>cancelamento só era possível com 24h de antecedência</strong>, então o valor virou prejuízo integral. O substituto, comprado às pressas pelo Booking, custou <strong>€ 40</strong> e saía às 15h. Resultado: <strong>€ 14 a mais por 3 horas a menos de passeio</strong> — e, o que doeu mais, sem Gozo no roteiro.
+  Eu tinha comprado dois passeios de barco pelo <strong>GetYourGuide — € 52,50 no total, € 26,25 cada</strong> —, saindo de San Pawl il-Baħar às 09h00 e voltando às 14h30. Dormimos demais e perdemos os dois. O <strong>cancelamento só era possível com 24h de antecedência</strong>, então o valor virou prejuízo integral. O substituto, comprado às pressas pelo Booking, custou <strong>€ 40</strong> e saía às 15h. Resultado: <strong>€ 14 a mais por 3 horas a menos de passeio</strong> — e, o que doeu mais, sem Gozo no roteiro.
 </div>
 
 <div class="divider">· · ·</div>
@@ -239,15 +239,17 @@ Chegamos, largamos as mochilas e fomos direto para **Paceville** — que fica li
 
 ### Jantar no Hugo's
 
-Jantamos no **Hugo's**, uma rede que é praticamente instituição na região e tem várias casas na mesma rua. Peguei o **combo do hambúrguer nº 6** — carne desfiada com molho Jack Daniel's, batata frita, refrigerante — mais uma porção de nuggets: **€ 20**. Meu amigo pediu o mesmo combo sem os nuggets: **€ 15**.
+Jantamos no **Hugo's**, uma rede que é praticamente instituição na região e tem várias casas na mesma rua. Peguei o **combo do hambúrguer nº 6** — carne desfiada com molho Jack Daniel's, batata frita, refrigerante — mais uma porção de nuggets: **€ 20,40**. Meu amigo pediu o mesmo combo sem os nuggets: **€ 15,40**.
 
 Para o padrão de Paceville, que cobra caro justamente por estar no meio do agito, € 15–20 por um combo completo é preço honesto.
 
 ### Pool party no rooftop do Society (até 23h)
 
-Saindo do Hugo's, entramos no **Society Hotel**, onde acontecia uma **pool party no rooftop**. Entrada: **€ 20**. Ficamos das **20h09 às 22h50** — quase 2h45 — e ainda passamos no hotel antes de sair de novo. Éramos só dois nessa etapa — o terceiro do grupo ainda não tinha chegado a Malta.
+Saindo do Hugo's, entramos no **So City Rooftop**, no Society Hotel, onde acontecia uma **pool party**. Ficamos das **20h09 às 22h50** — quase 2h45 — e ainda passamos no hotel antes de sair de novo. Éramos só dois nessa etapa: o terceiro do grupo ainda não tinha chegado a Malta.
 
-O consumo interno seguia exatamente o mesmo padrão do resto da ilha: **€ 5 por dose/bebida**. Foram 3 a 4 rodadas para cada um, o que deu **€ 15–20 por pessoa** em bebida.
+Gastei **€ 22** em bebida ali — uma rodada. A **entrada e a primeira rodada foram pagas pelo amigo que estava comigo**, numa troca informal: eu tinha comprado os ingressos do passeio de barco dos dois, e ele compensou cobrindo o rooftop. O consumo seguia o padrão da ilha: **€ 5 por dose**.
+
+Antes de subir, às 21h56, passamos num **Shop Express** e gastei **€ 19,80** entre água, cerveja, chiclete, vape e o primeiro par de chinelos da viagem — que não sobreviveria até o fim.
 
 <div class="callout callout-tip">
   <div class="callout-label">A sequência natural da noite em Paceville</div>
@@ -258,13 +260,14 @@ O consumo interno seguia exatamente o mesmo padrão do resto da ilha: **€ 5 po
 
 À **meia-noite** fomos para a **Toy Room (by Pacha)** — a casa de Paceville, que não deve ser confundida com o **Toy Room Beach Club de Sliema**, da mesma marca, que aparece no Dia 5 deste relato. São dois lugares diferentes, com estruturas e preços diferentes.
 
-Compramos a entrada com uma promoter na rua: **€ 25 por pessoa**, pagos por **transferência via Revolut** ali mesmo na calçada. A entrada dava direito a uma festa em beach club no dia seguinte — que não aproveitamos.
+Compramos a entrada com uma promoter na rua: **€ 25 por pessoa**, pagos por **transferência via Revolut** ali mesmo na calçada — o extrato registra o nome dela, não o da casa. A entrada dava direito a uma festa em beach club no dia seguinte — que não aproveitamos.
 
 **Como funciona o consumo:**
-- Sistema de pulseira recarregável: você carrega **€ 20 e recebe 4 drinks** (≈ € 5 por bebida)
+- Sistema de pulseira recarregável: você carrega **€ 20 e recebe 4 drinks** (≈ € 5 por bebida). Recarreguei duas vezes, **€ 40 no total**
 - Opção **VIP por € 50**, dando acesso a um mezanino acima da pista, com menos gente. Ficamos na pista mesmo
 - A casa fecha pontualmente às **04h00** (saímos por volta das 03h40)
 - Público bem jovem — faixa dos 17 aos 25 anos, majoritariamente estudantes e turistas italianos
+- Fechamos a madrugada com um sorvete de **€ 1,50** no Nico's, já a caminho do hotel
 - Estava bastante cheia na noite em que fomos
 
 <div class="callout callout-warn">
@@ -297,16 +300,16 @@ Fomos de **Bolt: € 30** saindo do ASTE — 14,6 km em 22 minutos até o noroes
 
 **Estrutura e preços:**
 - Espreguiçadeira: **€ 10 cada** (pegamos 3)
-- Guarda-sol: **€ 5 cada** (pegamos 2)
-- Bar de praia com água, cerveja (**€ 5,80**), iscas de peixe, iscas de frango e batata frita
+- Guarda-sol: **€ 5 cada** (pegamos 2) — cadeiras e guarda-sóis são cobrados pelo **Yarin Beach**, e paguei os **€ 35** do conjunto
+- Bar de praia (**Munchies Golden Bay**) com água, cerveja, iscas de peixe, iscas de frango e batata frita
 
-Entre cadeiras, guarda-sol, comida e bebida, gastei **≈ € 50** no dia de praia. A volta de Bolt custou **€ 30,40**.
+As cadeiras e o guarda-sol foram cobrados pelo **Yarin Beach** (€ 35) e o consumo no bar somou € 16,60 em duas comandas — **€ 51,60 no dia de praia**. A volta de Bolt custou **€ 30,40**.
 
 ### Café del Mar — festa Sundays (20h54–01h02)
 
 Passamos no hotel, trocamos de roupa e fomos para o **Café del Mar**, em Qawra, para a festa **Sundays**. Bolt: **€ 30**.
 
-Compramos os ingressos pelo site: **1 VIP a € 50 e 2 normais a € 25** (os VIPs tinham esgotado). Na porta, conseguimos **trocar os três por VIP sem custo adicional** — e no fim nem usamos a área VIP.
+Compramos os ingressos pelo site: **1 VIP a € 50 e 2 normais a € 25** (os VIPs tinham esgotado) — o VIP saiu no meu cartão. Na porta, conseguimos **trocar os três por VIP sem custo adicional**, e no fim nem usamos a área VIP.
 
 **Sobre o lugar:**
 - Espaço grande, **a céu aberto** — e estava bem quente
@@ -316,11 +319,11 @@ Compramos os ingressos pelo site: **1 VIP a € 50 e 2 normais a € 25** (os VI
 - O evento acaba **pontualmente à 01h00** — e ficamos até o fim
 - Rodada de bebidas (3 copos): **€ 17,20** — ou seja, ≈ € 5,73 por bebida
 
-Bebemos cerveja, Jägermeister e whisky com energético ou refrigerante. Foram **9 rodadas no total entre os três** — 9 copos por pessoa, 27 no total: **€ 154,80**, ou **€ 51,60 por pessoa**.
+Bebemos cerveja, Jägermeister e whisky com energético ou refrigerante. Foram **9 rodadas no total entre os três** — 9 copos por pessoa, 27 no total. No meu cartão caíram cinco delas: três no caixa principal (€ 17,20, € 17,70 e € 17,70) e duas no bar interno, que aparece como *Marine Aquatic* (€ 17,20 cada). **€ 87 só de bebida** numa noite.
 
 ### Havana, Paceville
 
-Voltamos de Bolt ao hotel, trocamos de roupa de novo e fomos ao **Havana**, em Paceville. Entrada: **≈ € 20**. Bebidas a **€ 5,80**. A casa toca música latina e tropical, é grande e tem 2 ou 3 ambientes. Foram 4 rodadas, 4 bebidas por pessoa, 12 no total: **€ 69,60** (€ 23,20 por pessoa).
+Voltamos de Bolt ao hotel, trocamos de roupa de novo e fomos ao **Havana**, em Paceville — que no extrato aparece como *Paceville Entertainments*. Entrada: **€ 20**. A casa toca música latina e tropical, é grande e tem 2 ou 3 ambientes. Em bebida foram **€ 44,30**: uma comanda de € 20,70 e quatro rodadas de € 5,90.
 
 <div class="callout callout-warn">
   <div class="callout-label">O que realmente estoura o orçamento em Malta</div>
@@ -346,13 +349,13 @@ Voltamos de Bolt ao hotel, trocamos de roupa de novo e fomos ao **Havana**, em P
   <div class="section-title-wrap"><h2>Dia 3 — St. Peter's Pool, Marsaskala e Blue Grotto</h2></div>
 </div>
 
-Dormimos até tarde, almoçamos no **Hugo's** de novo (**€ 15**, combo sem nuggets, dessa vez com hambúrguer comum) e saímos para uma maratona pelo sudeste da ilha — três lugares em um dia, o que só é possível de Bolt (ou de carro).
+Dormimos até tarde, almoçamos no **Hugo's** de novo (**€ 15,40**, combo sem nuggets, dessa vez com hambúrguer comum) e saímos para uma maratona pelo sudeste da ilha — três lugares em um dia, o que só é possível de Bolt (ou de carro).
 
 ### St. Peter's Pool
 
 **Bolt: € 30**, 14,8 km em exatos 30 minutos. É uma **piscina natural de rocha calcária** perto de Marsaxlokk — sem areia, sem espreguiçadeira, sem estrutura. Só pedra, água turquesa e gente pulando dos paredões.
 
-É excelente para pular, mas **bastante rochoso** — não é lugar para quem quer deitar numa toalha. Consumimos água (€ 2), Coca-Cola (€ 4) e Corona (€ 5), gastando cerca de **€ 12 por pessoa**.
+É excelente para pular, mas **bastante rochoso** — não é lugar para quem quer deitar numa toalha. Não há bar no local, mas passa **ambulante**: comprei água e Coca-Cola por **€ 8**, pagos por transferência direto para a pessoa.
 
 ### Marsaskala — o que não funcionou
 
@@ -360,7 +363,7 @@ De St. Peter's fomos para **Marsaskala** em uma van/táxi avulso: **€ 20** pel
 
 E aqui vai um relato honesto: **não gostamos, e nem chegamos a parar**. Havia um restaurante bem em frente à praia, mas não entramos. Olhamos a faixa de areia — pequena e tomada por famílias com crianças — e a área de mergulho, cheia de barcos, e simplesmente **começamos a andar na direção oposta**.
 
-Caminhamos 863 metros até a segunda faixa de areia e pedimos o Bolt dali, que **demorou 20 minutos para chegar**. No fim, o que era para ser uma parada de praia virou 45 minutos de caminhada e espera pela orla — das 17h17 às 18h02.
+Ainda compramos 3 Gatorades e 3 águas por **€ 9** de um vendedor local. Caminhamos 863 metros até a segunda faixa de areia e pedimos o Bolt dali, que **demorou 20 minutos para chegar**. No fim, o que era para ser uma parada de praia virou 45 minutos de caminhada e espera pela orla — das 17h17 às 18h02.
 
 Nada contra o lugar — Marsaskala é claramente uma cidade de veraneio familiar, e cumpre bem esse papel. Só não é o destino certo para um grupo de amigos procurando praia com estrutura.
 
@@ -406,7 +409,7 @@ Ficamos mais um pouco no **Qube Club**, ao lado, de música latina, que também 
   <div class="section-title-wrap"><h2>Dia 4 — Comino, Blue Lagoon e Crystal Lagoon</h2></div>
 </div>
 
-Só saímos do hotel às 14h43 — quase seis horas depois da saída do passeio que tínhamos comprado. Prejuízo assumido, compramos outro na hora: **€ 40 pelo Booking**, com saída de Sliema no início da tarde.
+Só saímos do hotel às 14h43 — quase seis horas depois da saída do passeio que tínhamos comprado. Prejuízo assumido, compramos outro na hora: **€ 40 pelo Booking**, com saída de Sliema no início da tarde. Quem pagou na hora foi um amigo, e eu transferi a minha parte depois.
 
 ### O passeio que perdemos × o passeio que fizemos
 
@@ -559,7 +562,7 @@ Fomos andando na direção do Toy Room e constatamos que dali para a frente não
 
 Somando tudo — descer do Bolt, a ida e volta a pé pela orla, o tempo esperando as amigas em Exiles Bay e a caminhada final até o restaurante —, foram **5,75 km em 1h44**, das 13h39 às 15h23. Cerca de 3,6 milhas.
 
-Pelo caminho comprei uma garrafa de água de 2 litros num truck de sorvete (**€ 2,50**, às 13h49) e, mais tarde, uma **sandália de € 9,99** às 15h25 — o chinelo que eu tinha comprado na ilha arrebentou. O substituto acabou ficando no ASTE quando fui embora.
+Pelo caminho comprei uma garrafa de água de 2 litros num truck de sorvete (**€ 2,50**, às 13h49) e, mais tarde, uma **sandália de € 9,99** às 15h25 (paga pela conta em dirham do Revolut) — o chinelo que eu tinha comprado na ilha arrebentou. O substituto acabou ficando no ASTE quando fui embora.
 
 Voltamos ao hotel pensando em pegar a piscina, mas já eram quase 17h e estava na hora dele sair para o aeroporto. Acabamos ficando no quarto: eu dormi um pouco e ele arrumou a mala.
 
@@ -589,7 +592,7 @@ Depois do jantar caminhamos do UMI até o **Canifor Hotel**, onde elas estavam: 
   <div class="section-title-wrap"><h2>Dia 7 — O dia de não fazer nada</h2></div>
 </div>
 
-Tinha combinado de ir a **Valletta** com as amigas, mas fiquei no hotel dormindo. Depois peguei a piscina da cobertura, e pedi **KFC duas vezes ao longo do dia — € 27,82 no total** — assistindo série no quarto.
+Tinha combinado de ir a **Valletta** com as amigas, mas fiquei no hotel dormindo. Depois peguei a piscina da cobertura, e pedi **KFC duas vezes ao longo do dia — € 27,82 no total**, pagos com RevPoints e pela conta em dirham — assistindo série no quarto.
 
 Todo mundo já tinha ido embora — elas voltaram para Dublin naquele dia, depois de passarem a manhã e a tarde em Valletta.
 
@@ -986,7 +989,7 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
     <tr><td>Transporte (Bolt, táxis e ônibus)</td><td>€ 147,55</td><td>6,9%</td><td>≈ € 18,44/dia</td></tr>
     <tr><td>Praia e beach club (cadeiras, cama, consumo)</td><td>€ 145,00</td><td>6,8%</td><td>—</td></tr>
     <tr><td>Compras e outros (souvenirs, free shop, sandália, banheiro)</td><td>€ 126,61</td><td>5,9%</td><td>—</td></tr>
-    <tr><td>Passeios (Comino € 40 + passeio perdido € 26)</td><td>€ 66,00</td><td>3,1%</td><td>—</td></tr>
+    <tr><td>Passeios (Comino € 40 + passeio perdido € 26,25)</td><td>€ 66,00</td><td>3,1%</td><td>—</td></tr>
     <tr><td><strong>Total da viagem</strong></td><td><strong>€ 2.143,02</strong></td><td><strong>100%</strong></td><td><strong>≈ € 268/dia</strong></td></tr>
     <tr><td><strong>Total sem voos e hospedagem</strong></td><td><strong>€ 1.174,34</strong></td><td>—</td><td><strong>≈ € 147/dia</strong></td></tr>
   </tbody>
@@ -1002,7 +1005,7 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
     <tr><td>Dia 1</td><td>22/08 (Sáb)</td><td>Duas festas na mesma noite (Society + Toy Room)</td><td>€ 105,50</td></tr>
     <tr><td>Dia 2</td><td>23/08 (Dom)</td><td>Praia + duas festas + € 74,80 só de bebida</td><td>€ 208,26</td></tr>
     <tr><td>Dia 3</td><td>24/08 (Seg)</td><td>Quatro corridas de Bolt (€ 27,77) + pizza + duas baladas</td><td>€ 104,27</td></tr>
-    <tr><td>Dia 4</td><td>25/08 (Ter)</td><td>Dois passeios pagos (€ 66) + souvenirs + consumo no barco</td><td>€ 170,35</td></tr>
+    <tr><td>Dia 4</td><td>25/08 (Ter)</td><td>Dois passeios pagos (€ 66,25) + souvenirs + consumo no barco</td><td>€ 170,35</td></tr>
     <tr><td>Dia 5</td><td>26/08 (Qua)</td><td>Beach club completo (€ 111,50) + bebida de mercado + Footloose</td><td>€ 199,09</td></tr>
     <tr><td>Dia 6</td><td>27/08 (Qui)</td><td>Jantar no UMI (€ 113) + € 39,30 de Bolt para St. Paul's Bay</td><td>€ 243,88</td></tr>
     <tr><td>Dia 7</td><td>28/08 (Sex)</td><td>Só KFC (duas vezes)</td><td>€ 32,82</td></tr>
@@ -1020,7 +1023,7 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
 
 <div class="callout callout-tip">
   <div class="callout-label">Quanto custaria uma versão mais econômica</div>
-  Com as mesmas 7 noites, mas dividindo quarto o tempo todo (≈ € 470 em vez de € 685), sem os € 26 do passeio perdido, sem os € 82 do free shop e com consumo noturno moderado (≈ € 150 em vez de € 343), a mesma viagem sairia por <strong>≈ € 1.630</strong>, ou <strong>≈ € 1.347 sem os voos</strong>. Malta não é um destino barato como a Albânia, mas também não precisa custar € 2.140.
+  Com as mesmas 7 noites, mas dividindo quarto o tempo todo (≈ € 470 em vez de € 685), sem os € 26,25 do passeio perdido, sem os € 82 do free shop e com consumo noturno moderado (≈ € 150 em vez de € 343), a mesma viagem sairia por <strong>≈ € 1.630</strong>, ou <strong>≈ € 1.347 sem os voos</strong>. Malta não é um destino barato como a Albânia, mas também não precisa custar € 2.140.
 </div>
 
 <div class="divider">· · ·</div>
@@ -1063,7 +1066,7 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-umbrella-beach"></i> Golden Bay</div>
     <div class="provider-detail">Uma das poucas praias de areia de verdade em Malta, no noroeste da ilha. Bar de praia com comida e bebida. Boa para o fim da tarde e para o pôr do sol. Movimentada em agosto.</div>
-    <div class="provider-price">Espreguiçadeira € 10 · Guarda-sol € 5 · Cerveja € 5,80</div>
+    <div class="provider-price">Espreguiçadeira € 10 · Guarda-sol € 5 · Cerveja ≈ € 5,80</div>
   </div>
 
   <div class="provider-card">
@@ -1129,7 +1132,7 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-burger"></i> Hugo's — Paceville</div>
     <div class="provider-detail">Rede com várias casas na mesma rua de Paceville. Combos de hambúrguer com batata e refrigerante. O nº 6 é de carne desfiada com molho Jack Daniel's. Bom custo-benefício para a região.</div>
-    <div class="provider-price">Combo € 15 · Com nuggets € 20</div>
+    <div class="provider-price">Combo € 15,40 · Com nuggets € 20,40</div>
   </div>
 
   <div class="provider-card">
@@ -1157,15 +1160,15 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
   </div>
 
   <div class="provider-card">
-    <div class="provider-name"><i class="fas fa-champagne-glasses"></i> Society Hotel (rooftop) — Paceville</div>
+    <div class="provider-name"><i class="fas fa-champagne-glasses"></i> So City Rooftop (Society Hotel) — Paceville</div>
     <div class="provider-detail">Pool party no rooftop do hotel, encerrando às 23h — encaixa perfeitamente antes das baladas, que só enchem depois da meia-noite. Consumo no mesmo padrão da ilha.</div>
-    <div class="provider-price">Entrada € 20 · Dose/bebida € 5 · ≈ € 15–20/pessoa em consumo</div>
+    <div class="provider-price">€ 22 entre entrada e consumo · Dose/bebida € 5</div>
   </div>
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-record-vinyl"></i> Toy Room (by Pacha) — Paceville</div>
     <div class="provider-detail">A casa noturna de Paceville — não confundir com o Toy Room Beach Club de Sliema. Público jovem (17–25 anos), muito estudante e turista italiano. Pulseira recarregável. Fecha às 04h. Área VIP num nível acima da pista.</div>
-    <div class="provider-price">Entrada € 25 (promoter) · VIP € 50 · Pulseira € 20 = 4 drinks</div>
+    <div class="provider-price">Entrada € 25 (promoter, via Revolut) · VIP € 50 · Pulseira € 20 = 4 drinks</div>
   </div>
 
   <div class="provider-card">
@@ -1177,13 +1180,13 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-music"></i> Café del Mar — Qawra</div>
     <div class="provider-detail">Espaço grande e a céu aberto, no norte da ilha. Festa Sundays. Público mais velho (25–35) e mais arrumado que a média de Paceville. Termina pontualmente à 01h.</div>
-    <div class="provider-price">Ingresso € 25 · VIP € 50 · Rodada (3 copos) € 17,20</div>
+    <div class="provider-price">Ingresso € 25 · VIP € 50 · Rodada (3 copos) € 17,20 a € 17,70</div>
   </div>
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-guitar"></i> Havana — Paceville</div>
     <div class="provider-detail">Música latina e tropical. Casa grande, com 2 ou 3 ambientes distintos.</div>
-    <div class="provider-price">Entrada ≈ € 20 · Bebidas € 5,80</div>
+    <div class="provider-price">Entrada € 20,70 · Rodada € 5,90</div>
   </div>
 
   <div class="provider-card">

--- a/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
+++ b/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
@@ -31,7 +31,7 @@ locations:
     label: "Sliema, Malta"
 ---
 
-<p class="lead">Oito dias em Malta no fim de agosto, saindo de Dublin por € 283 ida e volta com escala em Manchester. Quatro praias completamente diferentes entre si, oito festas, a Blue Lagoon de Comino, um passeio perdido por dormir demais e um total de € 2.143,02 do bolso. Este é o relato completo — com todos os números e os gráficos de onde o dinheiro foi.</p>
+<p class="lead">Oito dias em Malta no fim de agosto, saindo de Dublin por € 283 ida e volta com escala em Manchester. Quatro praias completamente diferentes entre si, oito festas, a Blue Lagoon de Comino, um passeio perdido por dormir demais e um total de € 2.322,36 do bolso. Este é o relato completo — com todos os números e os gráficos de onde o dinheiro foi.</p>
 
 <div class="callout callout-tip">
   <div class="callout-label">Moeda e pagamentos</div>
@@ -176,43 +176,43 @@ Isso teve efeito prático real no roteiro: encontrar-se implicava 20 a 30 minuto
       <td>Dia 1 — Chegada</td>
       <td>22/08 (Sáb)</td>
       <td>DUB→MAN 06h09 · MAN→MLA 09h08 · Pouso em Malta 13h44 · Hotel 14h04 · Hugo's + pool party no Society 20h09–22h50 · Toy Room (by Pacha) 00h05–03h40</td>
-      <td>≈ € 106</td>
+      <td>≈ € 132</td>
     </tr>
     <tr>
       <td>Dia 2</td>
       <td>23/08 (Dom)</td>
-      <td>Golden Bay 13h19–18h27 · Café del Mar (festa Sundays) 20h54–01h02 · Havana em Paceville até ~04h30</td>
-      <td>≈ € 208</td>
+      <td>Golden Bay 13h19–18h27 · Café del Mar (festa Sundays) 20h54–01h02 · Hotel para trocar de roupa · Havana em Paceville 01h50–04h30, já na madrugada de segunda</td>
+      <td>≈ € 316</td>
     </tr>
     <tr>
       <td>Dia 3</td>
       <td>24/08 (Seg)</td>
       <td>Almoço no Hugo's 13h24–14h17 · St. Peter's Pool 15h01–16h52 · Marsaskala 17h17–18h02 · Blue Grotto 18h27–19h44 · Pizza no Claudio's · Irish Pub e duas baladas</td>
-      <td>≈ € 104</td>
+      <td>≈ € 84</td>
     </tr>
     <tr>
       <td>Dia 4</td>
       <td>25/08 (Ter)</td>
       <td>★ Passeio da manhã perdido · Ferry Sliema→Comino 15h04–16h19 · Blue Lagoon e Crystal Lagoon até 19h20 · Volta a Sliema 20h18 · Souvenirs · Asian Kingdom</td>
-      <td>≈ € 170</td>
+      <td>≈ € 201</td>
     </tr>
     <tr>
       <td>Dia 5</td>
       <td>26/08 (Qua)</td>
       <td>Festa do Branco no Toy Room Beach Club (Sliema) 14h20–19h · Jantar no Asian Kingdom · Footloose em Paceville até 05h</td>
-      <td>≈ € 199</td>
+      <td>≈ € 205</td>
     </tr>
     <tr>
       <td>Dia 6</td>
       <td>27/08 (Qui)</td>
       <td>Praia em Sliema + caminhada de 5,8 km pela orla 13h39–15h23 · Asian Kingdom · Jantar no UMI 21h52–23h24</td>
-      <td>≈ € 244</td>
+      <td>≈ € 253</td>
     </tr>
     <tr>
       <td>Dia 7</td>
       <td>28/08 (Sex)</td>
       <td>Dia de descanso · Piscina do hotel · KFC e série no quarto</td>
-      <td>≈ € 33</td>
+      <td>≈ € 53</td>
     </tr>
     <tr>
       <td>Dia 8 — Partida</td>
@@ -321,9 +321,9 @@ Compramos os ingressos pelo site: **1 VIP a € 50 e 2 normais a € 25** (os VI
 
 Bebemos cerveja, Jägermeister e whisky com energético ou refrigerante. Foram **9 rodadas no total entre os três** — 9 copos por pessoa, 27 no total. No meu cartão caíram cinco delas: três no caixa principal (€ 17,20, € 17,70 e € 17,70) e duas no bar interno, que aparece como *Marine Aquatic* (€ 17,20 cada). **€ 87 só de bebida** numa noite.
 
-### Havana, Paceville
+### Havana, Paceville (já na madrugada de segunda)
 
-Voltamos de Bolt ao hotel, trocamos de roupa de novo e fomos ao **Havana**, em Paceville — que no extrato aparece como *Paceville Entertainments*. Entrada: **€ 20**. A casa toca música latina e tropical, é grande e tem 2 ou 3 ambientes. Em bebida foram **€ 44,30**: uma comanda de € 20,70 e quatro rodadas de € 5,90.
+O Café del Mar encerrou à 01h em ponto. Voltamos de Bolt ao hotel, trocamos de roupa e só então fomos ao **Havana** — ou seja, a essa altura **já era segunda-feira**. Entramos por volta das 01h50 e ficamos até cerca de 04h30. No extrato a casa aparece como *Paceville Entertainments*. Entrada: **€ 20**. A casa toca música latina e tropical, é grande e tem 2 ou 3 ambientes. Em bebida foram **€ 44,30**: uma comanda de € 20,70 e quatro rodadas de € 5,90.
 
 <div class="callout callout-warn">
   <div class="callout-label">O que realmente estoura o orçamento em Malta</div>
@@ -592,13 +592,38 @@ Depois do jantar caminhamos do UMI até o **Canifor Hotel**, onde elas estavam: 
   <div class="section-title-wrap"><h2>Dia 7 — O dia de não fazer nada</h2></div>
 </div>
 
-Tinha combinado de ir a **Valletta** com as amigas, mas fiquei no hotel dormindo. Depois peguei a piscina da cobertura, e pedi **KFC duas vezes ao longo do dia — € 27,82 no total**, pagos com RevPoints e pela conta em dirham — assistindo série no quarto.
+Tinha combinado de ir a **Valletta** com as amigas, mas fiquei no hotel dormindo. Depois peguei a piscina da cobertura e assisti série no quarto, com **dois pedidos de KFC pelo Wolt** ao longo do dia.
 
 Todo mundo já tinha ido embora — elas voltaram para Dublin naquele dia, depois de passarem a manhã e a tarde em Valletta.
 
+**Primeiro pedido — € 25,55**, pago às 05h06 com RevPoints e entregue às 05h23:
+
+- Original Recipe Chicken 3 pcs, meal com arroz e Pepsi Zero grande — € 15,55
+- Adicional de Caramel Sundae — € 2,00
+- Fries large — € 3,07
+- Hot Wings 5 pcs — € 5,90
+- Taxa de serviço — € 0,40 · Entrega grátis
+
+O Caramel Sundae não veio: mandaram duas Pepsi no lugar. Reclamei e recebi **€ 2 de volta como crédito**.
+
+**Segundo pedido — € 29,82, pagos € 27,82** com o crédito, às 23h41, entregue à 00h35:
+
+- Original Recipe Chicken 3 pcs, meal com fries large e Pepsi Zero grande — € 15,55
+- Adicional de Caramel Sundae — € 2,00
+- Churros 12 pcs com caramelo e chocolate branco — € 7,90
+- Hot Wings 5 pcs — € 5,90
+- Taxa de serviço — € 0,47 · Entrega grátis
+
+E aconteceu de novo: o Caramel Sundae, que eu nem tinha percebido que estava selecionado, não veio — dessa vez compensado com uma Fanta laranja extra. Não reclamei.
+
+<div class="callout callout-tip">
+  <div class="callout-label">Wolt em Malta</div>
+  O delivery funciona pelo <strong>Wolt</strong>, que pertence ao mesmo grupo do Deliveroo — a mesma lógica de marcas regionais que a Delivery Hero usa ao operar como Talabat no Oriente Médio. Se você já usa qualquer um deles, a conta e o método de pagamento costumam funcionar direto. Nos dois pedidos a <strong>entrega saiu de graça</strong>, com taxa de serviço abaixo de € 0,50.
+</div>
+
 <div class="callout callout-tip">
   <div class="callout-label">Reserve um dia de nada</div>
-  Este foi o dia mais barato da viagem: <strong>€ 32,82 no total</strong>, contra os € 244 do Dia 6. Depois de cinco dias de praia, Bolt e balada até de madrugada, um dia inteiro sem sair do hotel não é desperdício de viagem — é o que torna os outros sustentáveis. Se o seu roteiro tem 7 ou 8 dias, planeje um deles para não fazer absolutamente nada.
+  Mesmo com dois pedidos de KFC, foi o dia mais barato da viagem: <strong>€ 53,37</strong>, contra os € 316 do Dia 2. Depois de cinco dias de praia, Bolt e balada até de madrugada, um dia inteiro sem sair do hotel não é desperdício de viagem — é o que torna os outros sustentáveis. Se o seu roteiro tem 7 ou 8 dias, planeje um deles para não fazer absolutamente nada.
 </div>
 
 <div class="photo-gallery">
@@ -824,6 +849,8 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
   </tbody>
 </table>
 
+<p style="opacity: 0.75; font-size: 0.9rem;">Como as corridas eram pedidas em rodízio, o que efetivamente saiu do meu bolso foram <strong>€ 165,20</strong> — oito corridas de Bolt, o ônibus da chegada e o Bolt do último dia. A diferença para os € 147,55 da coluna acima é o que sobrou desbalanceado no rodízio, e é esse valor real que aparece na tabela de custos da seção 17.</p>
+
 ### O que diz a lei maltesa sobre dirigir e beber
 
 Antes de decidir por carro ou app, vale conhecer os números — e eles são mais apertados do que a fama de Malta sugere.
@@ -881,52 +908,57 @@ Mas em vários momentos da viagem voltamos a cogitar o aluguel, nem que fosse po
   <div class="section-title-wrap"><h2>Custos — os gráficos da viagem</h2></div>
 </div>
 
-O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e hospedagem**. Antes das tabelas, os dois gráficos que mostram melhor onde o dinheiro foi.
+O total da viagem foi de **€ 2.322,36**, ou **€ 1.353,68 sem contar voos e hospedagem**.
+
+<div class="callout callout-tip">
+  <div class="callout-label">Como esses números foram levantados</div>
+  Todos os valores abaixo saem de <strong>extratos reais</strong>, não de estimativas: conta em euro do Revolut, conta em dirham, RevPoints e Wise. Uma convenção importante: <strong>cada noite foi contabilizada no dia em que ela começou</strong>. A balada de sábado que varou até as 03h40, e o Havana que só abriu depois da 01h de segunda, entram respectivamente no Dia 1 e no Dia 2 — porque foi ali que a noite começou. Vale um aviso para quem for tentar o mesmo: as datas do extrato do Revolut são de <strong>liquidação, não de compra</strong>, com atraso de 1 a 3 dias — um táxi de segunda à noite aparece como despesa de quarta. Para reconstruir a viagem dia a dia foi preciso cruzar o extrato com o histórico do app de transporte e com o registro de localização do celular.
+</div>
 
 ### Gasto por dia
 
 <div style="margin: 2rem 0; font-size: 0.9rem;">
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 1 · 22/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 56.7% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 105,50</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 58.3% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 131,70</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 2 · 23/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 14.6% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 208,26</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 315,94</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 3 · 24/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 57.2% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 104,27</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 73.6% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 83,53</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 4 · 25/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 30.1% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 170,35</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 36.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 200,65</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 5 · 26/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 18.4% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 199,09</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 35.0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 205,29</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 6 · 27/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 243,88</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 19.9% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 253,03</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 7 · 28/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 86.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 32,82</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 83.1% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 53,37</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem;">
     <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 8 · 29/08</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 54.8% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 65.1% 0 0; background: currentColor; border-radius: 3px;"></div></div>
     <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 110,17</div>
   </div>
-  <p style="opacity: 0.6; font-size: 0.8rem; margin-top: 0.75rem;">Gastos diários por pessoa, sem voos e hospedagem. Total: € 1.174,34.</p>
+  <p style="opacity: 0.6; font-size: 0.8rem; margin-top: 0.75rem;">Gastos diários, sem voos e hospedagem. Total: € 1.353,68.</p>
 </div>
 
 ### Gasto por categoria
@@ -935,63 +967,63 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 9rem; opacity: 0.75;">Hospedagem</div>
     <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 685,68 · 32%</div>
-  </div>
-  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
-    <div style="flex: 0 0 9rem; opacity: 0.75;">Alimentação</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 49.6% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 345,65 · 16%</div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 685,68 · 30%</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 9rem; opacity: 0.75;">Festas e bebidas</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 49.9% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 343,53 · 16%</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 37.1% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 431,14 · 19%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Alimentação</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 43.7% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 386,23 · 17%</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 9rem; opacity: 0.75;">Voos</div>
     <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 58.7% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 283,00 · 13%</div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 283,00 · 12%</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 9rem; opacity: 0.75;">Transporte</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 78.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 147,55 · 7%</div>
-  </div>
-  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
-    <div style="flex: 0 0 9rem; opacity: 0.75;">Praia e beach club</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 78.9% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 145,00 · 7%</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 75.9% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 165,20 · 7%</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
     <div style="flex: 0 0 9rem; opacity: 0.75;">Compras e outros</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 81.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 126,61 · 6%</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 78.3% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 148,61 · 6%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Praia e beach club</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 81.0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 130,00 · 6%</div>
   </div>
   <div style="display: flex; align-items: center; gap: 0.75rem;">
     <div style="flex: 0 0 9rem; opacity: 0.75;">Passeios</div>
-    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 90.4% 0 0; background: currentColor; border-radius: 3px;"></div></div>
-    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 66,00 · 3%</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 86.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 92,50 · 4%</div>
   </div>
-  <p style="opacity: 0.6; font-size: 0.8rem; margin-top: 0.75rem;">Total por pessoa: € 2.143,02.</p>
+  <p style="opacity: 0.6; font-size: 0.8rem; margin-top: 0.75rem;">Total: € 2.322,36.</p>
 </div>
 
 ### Tabela completa por categoria
 
 <table class="compare-table">
   <thead>
-    <tr><th>Categoria</th><th>Total/pessoa</th><th>% do total</th><th>Por dia (8 dias)</th></tr>
+    <tr><th>Categoria</th><th>Total</th><th>% do total</th><th>Por dia (8 dias)</th></tr>
   </thead>
   <tbody>
-    <tr><td>Hospedagem (7 noites + late checkout)</td><td>€ 685,68</td><td>32,0%</td><td>≈ € 97,95/noite</td></tr>
-    <tr><td>Alimentação</td><td>€ 345,65</td><td>16,1%</td><td>≈ € 43,21/dia</td></tr>
-    <tr><td>Festas, entradas e bebidas noturnas</td><td>€ 343,53</td><td>16,0%</td><td>≈ € 42,94/dia</td></tr>
-    <tr><td>Voos (Kiwi, ida e volta)</td><td>€ 283,00</td><td>13,2%</td><td>—</td></tr>
-    <tr><td>Transporte (Bolt, táxis e ônibus)</td><td>€ 147,55</td><td>6,9%</td><td>≈ € 18,44/dia</td></tr>
-    <tr><td>Praia e beach club (cadeiras, cama, consumo)</td><td>€ 145,00</td><td>6,8%</td><td>—</td></tr>
-    <tr><td>Compras e outros (souvenirs, free shop, sandália, banheiro)</td><td>€ 126,61</td><td>5,9%</td><td>—</td></tr>
-    <tr><td>Passeios (Comino € 40 + passeio perdido € 26,25)</td><td>€ 66,00</td><td>3,1%</td><td>—</td></tr>
-    <tr><td><strong>Total da viagem</strong></td><td><strong>€ 2.143,02</strong></td><td><strong>100%</strong></td><td><strong>≈ € 268/dia</strong></td></tr>
-    <tr><td><strong>Total sem voos e hospedagem</strong></td><td><strong>€ 1.174,34</strong></td><td>—</td><td><strong>≈ € 147/dia</strong></td></tr>
+    <tr><td>Hospedagem (7 noites + late checkout)</td><td>€ 685,68</td><td>29,5%</td><td>≈ € 97,95/noite</td></tr>
+    <tr><td>Festas, entradas e bebidas noturnas</td><td>€ 431,14</td><td>18,6%</td><td>≈ € 53,89/dia</td></tr>
+    <tr><td>Alimentação</td><td>€ 386,23</td><td>16,6%</td><td>≈ € 48,28/dia</td></tr>
+    <tr><td>Voos (Kiwi, ida e volta)</td><td>€ 283,00</td><td>12,2%</td><td>—</td></tr>
+    <tr><td>Transporte (Bolt, táxis e ônibus)</td><td>€ 165,20</td><td>7,1%</td><td>≈ € 20,65/dia</td></tr>
+    <tr><td>Compras e outros (souvenirs, free shop, chinelos, mercadinho)</td><td>€ 148,61</td><td>6,4%</td><td>—</td></tr>
+    <tr><td>Praia e beach club (cadeiras, cama, consumo)</td><td>€ 130,00</td><td>5,6%</td><td>—</td></tr>
+    <tr><td>Passeios (Comino € 40 + dois ingressos perdidos € 52,50)</td><td>€ 92,50</td><td>4,0%</td><td>—</td></tr>
+    <tr><td><strong>Total da viagem</strong></td><td><strong>€ 2.322,36</strong></td><td><strong>100%</strong></td><td><strong>≈ € 290/dia</strong></td></tr>
+    <tr><td><strong>Total sem voos e hospedagem</strong></td><td><strong>€ 1.353,68</strong></td><td>—</td><td><strong>≈ € 169/dia</strong></td></tr>
   </tbody>
 </table>
 
@@ -999,31 +1031,31 @@ O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e h
 
 <table class="compare-table">
   <thead>
-    <tr><th>Dia</th><th>Data</th><th>Principal responsável pelo valor</th><th>Gasto/pessoa</th></tr>
+    <tr><th>Dia</th><th>Data</th><th>Principal responsável pelo valor</th><th>Gasto</th></tr>
   </thead>
   <tbody>
-    <tr><td>Dia 1</td><td>22/08 (Sáb)</td><td>Duas festas na mesma noite (Society + Toy Room)</td><td>€ 105,50</td></tr>
-    <tr><td>Dia 2</td><td>23/08 (Dom)</td><td>Praia + duas festas + € 74,80 só de bebida</td><td>€ 208,26</td></tr>
-    <tr><td>Dia 3</td><td>24/08 (Seg)</td><td>Quatro corridas de Bolt (€ 27,77) + pizza + duas baladas</td><td>€ 104,27</td></tr>
-    <tr><td>Dia 4</td><td>25/08 (Ter)</td><td>Dois passeios pagos (€ 66,25) + souvenirs + consumo no barco</td><td>€ 170,35</td></tr>
-    <tr><td>Dia 5</td><td>26/08 (Qua)</td><td>Beach club completo (€ 111,50) + bebida de mercado + Footloose</td><td>€ 199,09</td></tr>
-    <tr><td>Dia 6</td><td>27/08 (Qui)</td><td>Jantar no UMI (€ 113) + € 39,30 de Bolt para St. Paul's Bay</td><td>€ 243,88</td></tr>
-    <tr><td>Dia 7</td><td>28/08 (Sex)</td><td>Só KFC (duas vezes)</td><td>€ 32,82</td></tr>
+    <tr><td>Dia 1</td><td>22/08 (Sáb)</td><td>Rooftop + Toy Room (€ 87 entre entrada e pulseira)</td><td>€ 131,70</td></tr>
+    <tr><td>Dia 2</td><td>23/08 (Dom)</td><td>Café del Mar: € 50 de ingresso e € 87 de bebida · Havana € 64,30</td><td>€ 315,94</td></tr>
+    <tr><td>Dia 3</td><td>24/08 (Seg)</td><td>Três praias de Bolt, pizza dividida e duas baladas baratas</td><td>€ 83,53</td></tr>
+    <tr><td>Dia 4</td><td>25/08 (Ter)</td><td>Os dois ingressos perdidos (€ 52,50) + o passeio novo + souvenirs</td><td>€ 200,65</td></tr>
+    <tr><td>Dia 5</td><td>26/08 (Qua)</td><td>Beach club completo (€ 111,50) + bebida de mercado + Footloose</td><td>€ 205,29</td></tr>
+    <tr><td>Dia 6</td><td>27/08 (Qui)</td><td>Jantar no UMI (€ 113) + € 47,60 de Bolt</td><td>€ 253,03</td></tr>
+    <tr><td>Dia 7</td><td>28/08 (Sex)</td><td>Dois pedidos de KFC pelo Wolt</td><td>€ 53,37</td></tr>
     <tr><td>Dia 8</td><td>29/08 (Sáb)</td><td>Free shop do aeroporto (€ 82,17) + sorvete + Bolt</td><td>€ 110,17</td></tr>
-    <tr><td><strong>Total</strong></td><td></td><td></td><td><strong>€ 1.174,34</strong></td></tr>
+    <tr><td><strong>Total</strong></td><td></td><td></td><td><strong>€ 1.353,68</strong></td></tr>
   </tbody>
 </table>
 
 <div class="callout callout-warn">
   <div class="callout-label">Onde o dinheiro realmente foi</div>
-  <p><strong>Hospedagem foi um terço de todo o orçamento</strong> — e quase metade disso veio das duas últimas noites sozinho (€ 319,85 por 2 noites, contra € 268,33 por 4 noites dividindo o triplo).</p>
-  <p><strong>Alimentação e festas empataram em € 344 cada</strong>, e cada uma sozinha superou a passagem aérea. Somadas, dão o dobro dos voos.</p>
-  <p>O dia mais caro (€ 244) foi <strong>sete vezes</strong> mais caro que o mais barato (€ 33). E o último dia, em que eu só tomei sorvete e peguei um Bolt, custou € 110 por causa do free shop — vale lembrar do duty free na hora de fechar o orçamento.</p>
+  <p><strong>Festas e bebidas noturnas custaram € 431 — mais que a passagem aérea, e mais que alimentação.</strong> É a categoria que define o orçamento de Malta em agosto, e a que mais se pode cortar sem mudar a viagem.</p>
+  <p><strong>O Dia 2 sozinho custou € 316</strong>, quase quatro vezes o Dia 3 (€ 84) — e os dois tiveram praia de dia e balada à noite. A diferença inteira está em <em>onde</em> se bebe: € 87 numa festa de beach club contra € 11,30 em duas casas de rua com cupom de pague 1 leve 2.</p>
+  <p>Hospedagem foi 30% do total, e quase metade disso veio das duas últimas noites sozinho: € 319,85 por 2 noites, contra € 268,33 por 4 noites dividindo o quarto triplo.</p>
 </div>
 
 <div class="callout callout-tip">
   <div class="callout-label">Quanto custaria uma versão mais econômica</div>
-  Com as mesmas 7 noites, mas dividindo quarto o tempo todo (≈ € 470 em vez de € 685), sem os € 26,25 do passeio perdido, sem os € 82 do free shop e com consumo noturno moderado (≈ € 150 em vez de € 343), a mesma viagem sairia por <strong>≈ € 1.630</strong>, ou <strong>≈ € 1.347 sem os voos</strong>. Malta não é um destino barato como a Albânia, mas também não precisa custar € 2.140.
+  Com as mesmas 7 noites, mas dividindo quarto o tempo todo (≈ € 470 em vez de € 685), sem os € 52,50 dos ingressos perdidos, sem os € 82 do free shop e com consumo noturno moderado (≈ € 150 em vez de € 431), a mesma viagem sairia por <strong>≈ € 1.690</strong>, ou <strong>≈ € 1.407 sem os voos</strong>. Malta não é um destino barato como a Albânia, mas também não precisa custar € 2.300.
 </div>
 
 <div class="divider">· · ·</div>

--- a/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
+++ b/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
@@ -1,13 +1,13 @@
 ---
 layout: post
 title: "Malta em 8 dias: St. Julian's, Comino e o sudeste da ilha — praias, baladas e os custos reais saindo de Dublin"
-description: "Relato completo de 8 dias em Malta saindo de Dublin: hotel em St. Julian's, Golden Bay, St. Peter's Pool, Blue Grotto, Blue Lagoon em Comino e a vida noturna de Paceville. Timeline dia a dia, custos reais por pessoa e dicas práticas."
+description: "Relato completo de 8 dias em Malta saindo de Dublin: hotel em St. Julian's, Golden Bay, St. Peter's Pool, Blue Grotto, Blue Lagoon em Comino e a vida noturna de Paceville. Timeline dia a dia, gráficos de custos reais por pessoa e dicas práticas."
 date: 2026-08-30
 categories: [Hobbies]
 subcategories:
   - "Hobbies/Travel & Places"
-tags: [viagem, malta, st-julians, paceville, sliema, comino, blue-lagoon, golden-bay, blue-grotto, st-peters-pool, marsaskala, mediterraneo, irlanda, dublin, praia, vida-noturna, beach-club, bolt, kiwi, guia-de-viagem, custos-reais, travel, places, locations, nightlife, beach]
-reading_time: 20
+tags: [viagem, malta, st-julians, paceville, sliema, comino, blue-lagoon, golden-bay, blue-grotto, st-peters-pool, marsaskala, crystal-lagoon, mediterraneo, irlanda, dublin, praia, vida-noturna, beach-club, bolt, kiwi, guia-de-viagem, custos-reais, travel, places, locations, nightlife, beach]
+reading_time: 22
 image: /assets/img/posts/malta-2026.jpg
 gallery: true
 locations:
@@ -31,17 +31,18 @@ locations:
     label: "Sliema, Malta"
 ---
 
-<p class="lead">Oito dias em Malta no fim de agosto, saindo de Dublin por € 283 ida e volta com escala em Manchester. Quatro praias completamente diferentes entre si, cinco baladas, a Blue Lagoon de Comino, um passeio perdido por dormir demais e um total de € 1.931,91 do bolso. Este é o relato completo — com todos os números.</p>
+<p class="lead">Oito dias em Malta no fim de agosto, saindo de Dublin por € 283 ida e volta com escala em Manchester. Quatro praias completamente diferentes entre si, oito festas, a Blue Lagoon de Comino, um passeio perdido por dormir demais e um total de € 2.143,02 do bolso. Este é o relato completo — com todos os números e os gráficos de onde o dinheiro foi.</p>
 
 <div class="callout callout-tip">
   <div class="callout-label">Moeda e pagamentos</div>
-  Malta usa o <strong>Euro (€)</strong>. Praticamente tudo aceita cartão — bares, restaurantes, beach clubs e o app de transporte. Não precisei sacar dinheiro em espécie em nenhum momento dos 8 dias. As únicas exceções em que dinheiro vivo ajuda são os promoters de rua que vendem entrada de balada em Paceville e o banheiro pago do shopping em Sliema (€ 1).
+  Malta usa o <strong>Euro (€)</strong>. Em oito dias eu <strong>não usei dinheiro em espécie uma única vez</strong> — nem para o banheiro pago do shopping em Sliema (NFC pelo celular; cartão contactless também funciona), nem para o promoter de rua que vendeu a entrada da balada, que aceitou <strong>transferência por Revolut</strong> na hora. Cartão e pagamento por aproximação funcionam em praticamente tudo, inclusive nos food trucks e no bar de praia.
 </div>
 
 <div class="callout callout-warn">
   <div class="callout-label">Transparência sobre este relato</div>
-  <p>Esta foi minha <strong>segunda vez em Malta</strong> — a primeira foi em 2022. Por isso, este roteiro deliberadamente <strong>pula Valletta, Gozo e a Popeye Village</strong>: eu já conhecia os três e preferi usar o tempo em lugares novos. Se é a sua primeira viagem à ilha, esses três destinos precisam entrar no seu roteiro, e eu explico o porquê na seção 12.</p>
-  <p>Os valores são todos reais e foram anotados durante a viagem, não reconstruídos depois. Onde algo foi dividido em grupo, a divisão está explícita.</p>
+  <p>Esta foi minha <strong>segunda viagem a Malta</strong> — a primeira foi em maio de 2022, e ainda fiz uma escala na virada de 2025 para 2026, voltando da Grécia, em que passei a madrugada inteira num bar esperando o voo para a Irlanda. Ou seja: eu já conhecia Paceville e boa parte da ilha antes de embarcar.</p>
+  <p>Por isso este roteiro <strong>pula deliberadamente Valletta, Mdina e a Popeye Village</strong> — todos visitados em 2022. E deixa de fora <strong>Gozo</strong>, que continua sendo a grande lacuna: em três passagens por Malta, nunca fui. Explico os dois casos na seção 14.</p>
+  <p>Todos os valores foram anotados durante a viagem, não reconstruídos depois. Onde algo foi dividido em grupo, a divisão está explícita.</p>
 </div>
 
 <div class="divider">· · ·</div>
@@ -72,10 +73,14 @@ Um amigo comprou a passagem dele no dia 04/08 (dez dias depois da minha) para o 
 
 <div class="callout callout-tip">
   <div class="callout-label">Self-transfer em Manchester: por que deu certo</div>
-  A conexão em Manchester tinha só <strong>1h15</strong>, e eram bilhetes separados (self-transfer do Kiwi). Três fatores fizeram funcionar: (1) Irlanda e Reino Unido estão na <strong>Common Travel Area</strong>, então <strong>não há controle de imigração</strong> saindo de Dublin; (2) a primeira perna era Aer Lingus, que costuma ser pontual; (3) com bagagem de mão apenas, não existe risco de mala não ser transferida. Se qualquer um desses três fatores mudar — companhia menos pontual, bagagem despachada ou origem fora da CTA — 1h15 vira um risco real.
+  A conexão em Manchester tinha pouco mais de <strong>1h20</strong> na prática — pousei às 07h48 e o voo para Malta saiu às 09h08 — e eram bilhetes separados (self-transfer do Kiwi). Três fatores fizeram funcionar: (1) Irlanda e Reino Unido estão na <strong>Common Travel Area</strong>, então <strong>não há controle de imigração</strong> saindo de Dublin; (2) a primeira perna era Aer Lingus, que costuma ser pontual; (3) com bagagem de mão apenas, não existe risco de mala não ser transferida. Se qualquer um desses três fatores mudar — companhia menos pontual, bagagem despachada ou origem fora da CTA — 1h15 vira um risco real.
 </div>
 
-Na chegada ao aeroporto de Malta, eu e um dos amigos pegamos o **ônibus TD2/TD3 direto para St. Julian's: € 3,00 por pessoa**. O terceiro do grupo chegou em outro voo e foi de táxi, gastando cerca de € 15. A diferença é de € 12 por pessoa numa corrida de 20 minutos — o ônibus vale muito a pena quando você não está com pressa nem com mala grande.
+### Do aeroporto a St. Julian's
+
+Chegamos em horários diferentes: um amigo pousou de manhã e pegou o **ônibus TD2**; eu cheguei à tarde e peguei o **TD3**. Ambas as linhas fazem o trajeto aeroporto → St. Julian's e custam **€ 3,00 por pessoa**. O terceiro do grupo veio de táxi, gastando cerca de € 15.
+
+A diferença é de € 12 por pessoa num trajeto de 20 minutos — pousei às 13h44 e estava no hotel às 14h04. Com bagagem de mão e sem pressa, o ônibus vale muito a pena.
 
 <div class="photo-gallery">
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-chegada-01.jpg" class="glightbox" data-gallery="malta-chegada" data-title="<!-- TODO: descrição — chegada em Malta -->">
@@ -106,7 +111,7 @@ Ficamos no **ASTE Hotel**, em St. Julian's. A reserva foi fechada **em cima da h
 
 <table class="compare-table">
   <thead>
-    <tr><th>Período</th><th>Noites</th><th>Quarto</th><th>Total</th><th>Minha parte</th></tr>
+    <tr><th>Período</th><th>Noites</th><th>Reserva</th><th>Total</th><th>Minha parte</th></tr>
   </thead>
   <tbody>
     <tr><td>22 → 26/08</td><td>4</td><td>Triplo (3 pessoas)</td><td>€ 805,00</td><td>€ 268,33</td></tr>
@@ -117,15 +122,26 @@ Ficamos no **ASTE Hotel**, em St. Julian's. A reserva foi fechada **em cima da h
   </tbody>
 </table>
 
+<div class="callout callout-tip">
+  <div class="callout-label">Paguei single e fiquei no triplo — por cortesia do hotel</div>
+  As duas últimas noites foram reservadas e pagas como <strong>quarto single</strong>, mas o ASTE me deixou permanecer no <strong>mesmo quarto triplo</strong> em que estávamos desde o primeiro dia, sem custo adicional e sem troca. Ou seja: <strong>não precisei mudar de quarto em nenhum momento dos 8 dias</strong> — nem quando o grupo diminuiu, nem quando a reserva mudou de categoria. Vale perguntar na recepção antes de arrumar a mala; nem sempre a troca é necessária.
+</div>
+
 <div class="callout callout-warn">
   <div class="callout-label">O número que mais dói: viajar sozinho em alta temporada</div>
-  Dividindo o quarto triplo, a diária saiu por <strong>€ 67 por pessoa</strong>. Nas duas últimas noites, sozinho no single, a diária foi de <strong>€ 160</strong>. Mais que o dobro — e essas duas noites sozinhas custaram quase o mesmo que a passagem aérea inteira ida e volta. Se você tem flexibilidade de datas, alinhar o período com o do grupo economiza mais do que qualquer promoção de voo.
+  Dividindo o quarto triplo, a diária saiu por <strong>€ 67 por pessoa</strong>. Nas duas últimas noites, sozinho, a diária foi de <strong>€ 160</strong>. Mais que o dobro — e essas duas noites custaram quase o mesmo que a passagem aérea inteira ida e volta. Se você tem flexibilidade de datas, alinhar o período com o do grupo economiza mais do que qualquer promoção de voo.
 </div>
 
 <div class="callout callout-tip">
   <div class="callout-label">Late checkout por hora — vale a pena?</div>
   O ASTE oferecia estender o checkout (originalmente 11h) por <strong>€ 15 por hora, até as 13h</strong>. Como meu voo só saía às 20h, paguei € 30 e dormi até meio-dia. Depois deixei a mala na recepção e fiquei lá até as 17h sem custo nenhum. Foi dinheiro bem gasto: € 30 por duas horas de sono numa cama contra ficar rodando com mochila desde as 11h da manhã.
 </div>
+
+### As amigas ficaram em Buġibba
+
+Duas amigas que também moram em Dublin viajaram no mesmo período e ficaram no **Canifor Hotel**, em Buġibba, de **23 a 28 de agosto** — do outro lado da ilha em relação a St. Julian's.
+
+Isso teve efeito prático real no roteiro: encontrar-se implicava 20 a 30 minutos de Bolt ou uma viagem de ônibus, e mais de uma vez a noite delas terminou cedo só por causa do trajeto de volta. **Se o seu grupo vai se dividir em hotéis diferentes, considere seriamente a distância entre eles** — em Malta as distâncias são curtas no mapa, mas o deslocamento noturno pesa.
 
 <div class="photo-gallery">
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-hotel-01.jpg" class="glightbox" data-gallery="malta-hotel" data-title="<!-- TODO: descrição — ASTE Hotel -->">
@@ -159,93 +175,110 @@ Ficamos no **ASTE Hotel**, em St. Julian's. A reserva foi fechada **em cima da h
     <tr>
       <td>Dia 1 — Chegada</td>
       <td>22/08 (Sáb)</td>
-      <td>DUB→MAN 06h30 · MAN→MLA 08h45 · Ônibus TD2/TD3 até St. Julian's · Passeio por Paceville · Jantar no Hugo's · Pacha / Toy Room 00h–04h</td>
-      <td>≈ € 68</td>
+      <td>DUB→MAN 06h09 · MAN→MLA 09h08 · Pouso em Malta 13h44 · Hotel 14h04 · Hugo's + pool party no Society 20h09–22h50 · Toy Room (by Pacha) 00h05–03h40</td>
+      <td>≈ € 106</td>
     </tr>
     <tr>
       <td>Dia 2</td>
       <td>23/08 (Dom)</td>
-      <td>Golden Bay 13h–18h30 (espreguiçadeiras + bar de praia) · Café del Mar (Sundays) 20h–01h · Havana em Paceville até de madrugada</td>
+      <td>Golden Bay 13h19–18h27 · Café del Mar (festa Sundays) 20h54–01h02 · Havana em Paceville até ~04h30</td>
       <td>≈ € 208</td>
     </tr>
     <tr>
       <td>Dia 3</td>
       <td>24/08 (Seg)</td>
-      <td>Almoço no Hugo's · St. Peter's Pool · Marsaskala (1h) · Blue Grotto 18h30–19h45 · Pizza no Claudio's · Irish Pub · Balada de reggaeton · Balada latina</td>
-      <td>≈ € 100</td>
+      <td>Almoço no Hugo's 13h24–14h17 · St. Peter's Pool 15h01–16h52 · Marsaskala 17h17–18h02 · Blue Grotto 18h27–19h44 · Pizza no Claudio's · Irish Pub e duas baladas</td>
+      <td>≈ € 104</td>
     </tr>
     <tr>
       <td>Dia 4</td>
       <td>25/08 (Ter)</td>
-      <td>★ Passeio da manhã perdido · Passeio a Comino saindo de Sliema 15h–20h30 · Blue Lagoon · Souvenirs em Sliema · Jantar no Asian Kingdom</td>
-      <td>≈ € 127</td>
+      <td>★ Passeio da manhã perdido · Ferry Sliema→Comino 15h04–16h19 · Blue Lagoon e Crystal Lagoon até 19h20 · Volta a Sliema 20h18 · Souvenirs · Asian Kingdom</td>
+      <td>≈ € 170</td>
     </tr>
     <tr>
       <td>Dia 5</td>
       <td>26/08 (Qua)</td>
-      <td>Festa do Branco no Toy Room Beach Club (Sliema) 11h–19h · Jantar no Asian Kingdom · Footloose em Paceville</td>
-      <td>≈ € 217</td>
+      <td>Festa do Branco no Toy Room Beach Club (Sliema) 14h20–19h · Jantar no Asian Kingdom · Footloose em Paceville até 05h</td>
+      <td>≈ € 199</td>
     </tr>
     <tr>
       <td>Dia 6</td>
       <td>27/08 (Qui)</td>
-      <td>Praia em Sliema · Almoço no Asian Kingdom · Jantar no UMI em St. Paul's Bay</td>
-      <td>≈ € 200</td>
+      <td>Praia em Sliema + caminhada de 5,8 km pela orla 13h39–15h23 · Asian Kingdom · Jantar no UMI 21h52–23h24</td>
+      <td>≈ € 244</td>
     </tr>
     <tr>
       <td>Dia 7</td>
       <td>28/08 (Sex)</td>
       <td>Dia de descanso · Piscina do hotel · KFC e série no quarto</td>
-      <td>≈ € 20</td>
+      <td>≈ € 33</td>
     </tr>
     <tr>
       <td>Dia 8 — Partida</td>
       <td>29/08 (Sáb)</td>
-      <td>Late checkout às 13h · Recepção até as 17h · Sorvete de despedida · Bolt para o aeroporto · MLA→DUB 20h00 (atrasou)</td>
-      <td>≈ € 22</td>
+      <td>Late checkout às 13h · Recepção até 16h48 · Sorvete no RivaReno 16h50–17h05 · Bolt ao aeroporto 17h05–17h20 · MLA→DUB 20h00 (atrasou)</td>
+      <td>≈ € 110</td>
     </tr>
   </tbody>
 </table>
 
 <div class="callout callout-warn">
   <div class="callout-label">★ Nota sobre o Dia 4 — o passeio que virou pó</div>
-  Eu tinha um passeio de barco a Comino comprado pelo <strong>GetYourGuide por € 26</strong>, saindo de San Pawl il-Baħar às 09h00 e voltando às 14h30. Dormimos demais e perdemos. O <strong>cancelamento só era possível com 24h de antecedência</strong>, então o valor virou prejuízo integral. O substituto, comprado às pressas pelo Booking, custou <strong>€ 40</strong> e saía às 15h. Resultado: <strong>€ 14 a mais por 3 horas a menos de passeio</strong>.
+  Eu tinha um passeio de barco comprado pelo <strong>GetYourGuide por € 26</strong>, saindo de San Pawl il-Baħar às 09h00 e voltando às 14h30. Dormimos demais e perdemos. O <strong>cancelamento só era possível com 24h de antecedência</strong>, então o valor virou prejuízo integral. O substituto, comprado às pressas pelo Booking, custou <strong>€ 40</strong> e saía às 15h. Resultado: <strong>€ 14 a mais por 3 horas a menos de passeio</strong> — e, o que doeu mais, sem Gozo no roteiro.
 </div>
 
 <div class="divider">· · ·</div>
 
 <div class="section-header">
   <div class="section-num">04</div>
-  <div class="section-title-wrap"><h2>Dia 1 — Paceville, Hugo's e a primeira balada</h2></div>
+  <div class="section-title-wrap"><h2>Dia 1 — Paceville, pool party no Society e Toy Room</h2></div>
 </div>
 
-Chegamos, largamos as mochilas e fomos direto conhecer **Paceville** — que fica literalmente na rua de cima do hotel. É o bairro que concentra praticamente toda a vida noturna de Malta: baladas, bares e fast-food espremidos em poucos quarteirões, com St. George's Bay ali ao lado.
+Chegamos, largamos as mochilas e fomos direto para **Paceville** — que fica literalmente na rua de cima do hotel. É o bairro que concentra praticamente toda a vida noturna de Malta: baladas, bares e fast-food espremidos em poucos quarteirões, com St. George's Bay ao lado.
+
+### Jantar no Hugo's
 
 Jantamos no **Hugo's**, uma rede que é praticamente instituição na região e tem várias casas na mesma rua. Peguei o **combo do hambúrguer nº 6** — carne desfiada com molho Jack Daniel's, batata frita, refrigerante — mais uma porção de nuggets: **€ 20**. Meu amigo pediu o mesmo combo sem os nuggets: **€ 15**.
 
 Para o padrão de Paceville, que cobra caro justamente por estar no meio do agito, € 15–20 por um combo completo é preço honesto.
 
-À meia-noite fomos para a **Pacha / Toy Room**, comprando a entrada com uma promoter na rua: **€ 25 por pessoa**. A entrada dava direito a uma festa em beach club no dia seguinte — que não aproveitamos.
+### Pool party no rooftop do Society (até 23h)
 
-**Como funciona o consumo na Pacha:**
-- Sistema de pulseira recarregável: você carrega **€ 20 e recebe 4 drinks** (≈ € 5 por bebida)
-- Havia opção **VIP por € 50**, dando acesso a um mezanino acima da pista, com menos gente. Ficamos na pista mesmo
-- A casa fecha pontualmente às **04h00**
-- Público bem jovem — na faixa dos 17 aos 25 anos, majoritariamente estudantes e turistas italianos
-- Estava bastante cheia na noite em que fomos
+Saindo do Hugo's, entramos no **Society Hotel**, onde acontecia uma **pool party no rooftop**. Entrada: **€ 20**. Ficamos das **20h09 às 22h50** — quase 2h45 — e ainda passamos no hotel antes de sair de novo. Éramos só dois nessa etapa — o terceiro do grupo ainda não tinha chegado a Malta.
+
+O consumo interno seguia exatamente o mesmo padrão do resto da ilha: **€ 5 por dose/bebida**. Foram 3 a 4 rodadas para cada um, o que deu **€ 15–20 por pessoa** em bebida.
 
 <div class="callout callout-tip">
-  <div class="callout-label">Cuidado com o "combo" do promoter</div>
-  A entrada de € 25 incluía um beach club no dia seguinte, e a gente simplesmente não foi. Quatro dias depois acabei pagando <strong>€ 15 na porta</strong> por uma festa da mesma marca (Toy Room Beach Club). Ou seja: o combo do promoter era um bom negócio <em>se</em> você planejar o dia seguinte. Sem planejamento, você paga por duas coisas e usa uma.
+  <div class="callout-label">A sequência natural da noite em Paceville</div>
+  Repare no encaixe: a pool party do rooftop <strong>acaba às 23h</strong>, e as baladas de Paceville <strong>começam a encher por volta da meia-noite</strong>. Não é coincidência — é assim que a noite é desenhada por lá. Dá para emendar rooftop e balada na mesma noite sem tempo morto, e foi exatamente o que fizemos.
 </div>
 
-<!-- Nota: baladas raramente rendem foto. Se não houver imagem deste dia, remova o bloco abaixo. -->
+### Toy Room (by Pacha), Paceville (00h–04h)
+
+À **meia-noite** fomos para a **Toy Room (by Pacha)** — a casa de Paceville, que não deve ser confundida com o **Toy Room Beach Club de Sliema**, da mesma marca, que aparece no Dia 5 deste relato. São dois lugares diferentes, com estruturas e preços diferentes.
+
+Compramos a entrada com uma promoter na rua: **€ 25 por pessoa**, pagos por **transferência via Revolut** ali mesmo na calçada. A entrada dava direito a uma festa em beach club no dia seguinte — que não aproveitamos.
+
+**Como funciona o consumo:**
+- Sistema de pulseira recarregável: você carrega **€ 20 e recebe 4 drinks** (≈ € 5 por bebida)
+- Opção **VIP por € 50**, dando acesso a um mezanino acima da pista, com menos gente. Ficamos na pista mesmo
+- A casa fecha pontualmente às **04h00** (saímos por volta das 03h40)
+- Público bem jovem — faixa dos 17 aos 25 anos, majoritariamente estudantes e turistas italianos
+- Estava bastante cheia na noite em que fomos
+
+<div class="callout callout-warn">
+  <div class="callout-label">Cuidado com o "combo" do promoter</div>
+  A entrada de € 25 incluía um beach club no dia seguinte, e a gente simplesmente não foi. Quatro dias depois acabei pagando <strong>€ 15 na porta</strong> por uma festa da mesma marca (o Toy Room Beach Club de Sliema). Ou seja: o combo do promoter é um bom negócio <em>se</em> você planejar o dia seguinte. Sem planejamento, você paga por duas coisas e usa uma.
+</div>
+
+<!-- Nota: eventos noturnos raramente rendem foto. Se não houver imagem deste dia, remova o bloco abaixo. -->
 <div class="photo-gallery">
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia1-01.jpg" class="glightbox" data-gallery="malta-dia1" data-title="<!-- TODO: descrição — Paceville / Dia 1 -->">
     <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia1-01.jpg" alt="<!-- TODO: legenda — Dia 1 -->">
   </a>
-  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia1-02.jpg" class="glightbox" data-gallery="malta-dia1" data-title="<!-- TODO: descrição — Paceville / Dia 1 -->">
-    <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia1-02.jpg" alt="<!-- TODO: legenda — Dia 1 -->">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia1-02.jpg" class="glightbox" data-gallery="malta-dia1" data-title="<!-- TODO: descrição — pool party no rooftop do Society -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia1-02.jpg" alt="<!-- TODO: legenda — Society rooftop -->">
   </a>
 </div>
 
@@ -258,9 +291,9 @@ Para o padrão de Paceville, que cobra caro justamente por estar no meio do agit
 
 O dia mais caro da viagem, e por uma margem enorme.
 
-### Golden Bay (13h–18h30)
+### Golden Bay (13h19–18h27)
 
-Fomos de **Bolt: € 30** saindo do ASTE, cerca de 45 minutos até o noroeste da ilha. Golden Bay é uma das poucas **praias de areia de verdade** em Malta — a maioria do litoral maltês é rochosa — e por isso é uma das mais procuradas.
+Fomos de **Bolt: € 30** saindo do ASTE — 14,6 km em 22 minutos até o noroeste da ilha. Golden Bay é uma das poucas **praias de areia de verdade** em Malta — a maioria do litoral maltês é rochosa — e por isso é uma das mais procuradas.
 
 **Estrutura e preços:**
 - Espreguiçadeira: **€ 10 cada** (pegamos 3)
@@ -269,18 +302,18 @@ Fomos de **Bolt: € 30** saindo do ASTE, cerca de 45 minutos até o noroeste da
 
 Entre cadeiras, guarda-sol, comida e bebida, gastei **≈ € 50** no dia de praia. A volta de Bolt custou **€ 30,40**.
 
-### Café del Mar — festa Sundays (20h–01h)
+### Café del Mar — festa Sundays (20h54–01h02)
 
-Passamos no hotel, trocamos de roupa e fomos para o **Café del Mar**, em Qawra, para a festa **Sundays** (sundays.com.mt). Bolt: **€ 30**.
+Passamos no hotel, trocamos de roupa e fomos para o **Café del Mar**, em Qawra, para a festa **Sundays**. Bolt: **€ 30**.
 
 Compramos os ingressos pelo site: **1 VIP a € 50 e 2 normais a € 25** (os VIPs tinham esgotado). Na porta, conseguimos **trocar os três por VIP sem custo adicional** — e no fim nem usamos a área VIP.
 
 **Sobre o lugar:**
 - Espaço grande, **a céu aberto** — e estava bem quente
-- Chegamos às 20h e já era noite
-- Público mais velho que o da Pacha, na faixa dos 25 aos 35, com bastante gente de 18 a 25 também
+- Chegamos por volta das 21h e já era noite
+- Público mais velho que o da Toy Room, na faixa dos 25 aos 35, com bastante gente de 18 a 25 também
 - Todo mundo **bem mais arrumado** que na noite anterior
-- O evento acaba **pontualmente à 01h00**
+- O evento acaba **pontualmente à 01h00** — e ficamos até o fim
 - Rodada de bebidas (3 copos): **€ 17,20** — ou seja, ≈ € 5,73 por bebida
 
 Bebemos cerveja, Jägermeister e whisky com energético ou refrigerante. Foram **9 rodadas no total entre os três** — 9 copos por pessoa, 27 no total: **€ 154,80**, ou **€ 51,60 por pessoa**.
@@ -291,7 +324,7 @@ Voltamos de Bolt ao hotel, trocamos de roupa de novo e fomos ao **Havana**, em P
 
 <div class="callout callout-warn">
   <div class="callout-label">O que realmente estoura o orçamento em Malta</div>
-  Só de bebida, no Dia 2, foram <strong>€ 74,80 por pessoa</strong> — mais do que as entradas das duas festas somadas (€ 53,33) e mais do que o dia inteiro de praia com cadeiras e almoço (€ 50). E o preço se mantém estável entre uma casa premium como o Café del Mar (≈ € 5,73/copo) e uma balada de rua como o Havana (€ 5,80). O único desconto real que encontrei foi a pulseira da Pacha: € 20 por 4 drinks, ou € 5 cada.
+  Só de bebida, no Dia 2, foram <strong>€ 74,80 por pessoa</strong> — mais do que as entradas das duas festas somadas (€ 53,33) e mais do que o dia inteiro de praia com cadeiras e almoço (€ 50). E o preço se mantém estável entre uma casa premium como o Café del Mar (≈ € 5,73/copo) e uma balada de rua como o Havana (€ 5,80). O único desconto real que encontrei foi a pulseira da Toy Room: € 20 por 4 drinks, ou € 5 cada.
 </div>
 
 <div class="photo-gallery">
@@ -313,11 +346,11 @@ Voltamos de Bolt ao hotel, trocamos de roupa de novo e fomos ao **Havana**, em P
   <div class="section-title-wrap"><h2>Dia 3 — St. Peter's Pool, Marsaskala e Blue Grotto</h2></div>
 </div>
 
-Dormimos até tarde, almoçamos no **Hugo's** de novo (**€ 15**, combo sem nuggets, dessa vez com hambúrguer comum) e saímos para uma maratona pelo sudeste da ilha — três lugares em um dia, o que só é possível de Bolt.
+Dormimos até tarde, almoçamos no **Hugo's** de novo (**€ 15**, combo sem nuggets, dessa vez com hambúrguer comum) e saímos para uma maratona pelo sudeste da ilha — três lugares em um dia, o que só é possível de Bolt (ou de carro).
 
 ### St. Peter's Pool
 
-**Bolt: € 30**, cerca de 30 minutos. É uma **piscina natural de rocha calcária** perto de Marsaxlokk — sem areia, sem espreguiçadeira, sem estrutura. Só pedra, água turquesa e gente pulando dos paredões.
+**Bolt: € 30**, 14,8 km em exatos 30 minutos. É uma **piscina natural de rocha calcária** perto de Marsaxlokk — sem areia, sem espreguiçadeira, sem estrutura. Só pedra, água turquesa e gente pulando dos paredões.
 
 É excelente para pular, mas **bastante rochoso** — não é lugar para quem quer deitar numa toalha. Consumimos água (€ 2), Coca-Cola (€ 4) e Corona (€ 5), gastando cerca de **€ 12 por pessoa**.
 
@@ -325,13 +358,19 @@ Dormimos até tarde, almoçamos no **Hugo's** de novo (**€ 15**, combo sem nug
 
 De St. Peter's fomos para **Marsaskala** em uma van/táxi avulso: **€ 20** pelos três.
 
-E aqui vai um aviso honesto: **não gostamos**. A praia é muito pequena e o público é quase todo familiar — perfeitamente legítimo, mas nada a ver com o que a gente procurava. Ficamos cerca de 1 hora andando pela orla, boa parte disso só esperando o Bolt, que demorou **20 minutos só para chegar**.
+E aqui vai um relato honesto: **não gostamos, e nem chegamos a parar**. Havia um restaurante bem em frente à praia, mas não entramos. Olhamos a faixa de areia — pequena e tomada por famílias com crianças — e a área de mergulho, cheia de barcos, e simplesmente **começamos a andar na direção oposta**.
 
-### Blue Grotto (18h30–19h45)
+Caminhamos 863 metros até a segunda faixa de areia e pedimos o Bolt dali, que **demorou 20 minutos para chegar**. No fim, o que era para ser uma parada de praia virou 45 minutos de caminhada e espera pela orla — das 17h17 às 18h02.
+
+Nada contra o lugar — Marsaskala é claramente uma cidade de veraneio familiar, e cumpre bem esse papel. Só não é o destino certo para um grupo de amigos procurando praia com estrutura.
+
+### Blue Grotto (18h27–19h44)
 
 De Marsaskala para a **Blue Grotto**: **€ 15** de Bolt.
 
-A Blue Grotto **não tem praia** e a água é funda — você entra direto do costão. Chegamos às 18h30, quando os barcos de passeio já tinham encerrado o movimento, então nadamos ao lado das embarcações paradas, com o lugar praticamente vazio. Ficamos até as 19h45.
+A Blue Grotto **não tem praia** e a água é funda — você entra direto do costão. Chegamos às 18h27, e uma correção importante em relação ao que costuma se dizer sobre horários: **o lugar não estava vazio**. Havia entre 80 e 100 pessoas, sentadas do lado de fora e já dentro da água.
+
+O que estava parado eram **os barcos de passeio**, que já tinham encerrado o movimento do dia. Isso muda a experiência: dá para nadar tranquilamente ao lado das embarcações ancoradas, sem tráfego, mas sem a ilusão de ter o lugar só para você. Ficamos até as 19h44.
 
 <div class="callout callout-tip">
   <div class="callout-label">Motorista de app pode recusar passageiro molhado</div>
@@ -340,19 +379,19 @@ A Blue Grotto **não tem praia** e a água é funda — você entra direto do co
 
 ### A noite: pizza, Irish Pub e duas baladas
 
-Jantamos no **Claudio's Pizza**, bem em frente ao ASTE: **€ 57** por 3 pizzas e 4 refrigerantes (**€ 19 por pessoa**). Duas observações práticas: as pizzas são grandes o suficiente para um dos três não conseguir terminar e levar para viagem, mas nós outros dois comemos uma inteira cada sem dificuldade.
+Jantamos no **Claudio's Pizza**, bem em frente ao ASTE, por volta das 21h: **€ 58** por 3 pizzas e 4 refrigerantes (**€ 19,33 por pessoa**). As pizzas são grandes o suficiente para um dos três não conseguir terminar e levar para viagem — mas nós outros dois comemos uma inteira cada sem dificuldade.
 
 Quase à meia-noite fomos encontrar as amigas no **Irish Pub** de Paceville. Ali não gastamos nada — elas já estavam bebendo e nós tínhamos levado uma lata de Heineken.
 
-De lá fomos a uma **balada de reggaeton** em Paceville: **entrada gratuita**, bebida barata e um cupom de **compre 1 leve 2** (uso único). Uma rodada: **€ 5**. Por volta das 00h45 elas foram embora — o hotel delas ficava do outro lado da ilha, chegariam quase 01h30 e tinham passeio para Comino cedo no dia seguinte.
+De lá fomos ao **Flow Club**, de reggaeton: **entrada gratuita**, bebida barata e um cupom de **compre 1 leve 2** (uso único). Uma rodada às 23h59: **€ 5,40**. Por volta das 00h45 elas foram embora — o hotel delas ficava em Buġibba, chegariam quase 01h30 e tinham passeio para Comino cedo no dia seguinte.
 
-Ficamos mais um pouco numa **balada latina ao lado**, que também tinha o cupom de pague 1 leve 2. Outra rodada, **€ 5**. Voltamos ao hotel por volta das 02h.
+Ficamos mais um pouco no **Qube Club**, ao lado, de música latina, que também tinha o cupom de pague 1 leve 2. Outra rodada às 00h34: **€ 5,90**. No caminho de volta paramos no **La Dolceria**, o mercadinho entre Paceville e o hotel, para comprar água (**€ 2,20** à 01h47).
 
 <div class="photo-gallery">
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia3-01.jpg" class="glightbox" data-gallery="malta-dia3" data-title="<!-- TODO: descrição — St. Peter's Pool -->">
     <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia3-01.jpg" alt="<!-- TODO: legenda — St. Peter's Pool -->">
   </a>
-  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia3-02.jpg" class="glightbox" data-gallery="malta-dia3" data-title="<!-- TODO: descrição — Marsaskala -->">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia3-02.jpg" class="glightbox" data-gallery="malta-dia3" data-title="<!-- TODO: descrição — orla de Marsaskala -->">
     <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia3-02.jpg" alt="<!-- TODO: legenda — Marsaskala -->">
   </a>
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia3-03.jpg" class="glightbox" data-gallery="malta-dia3" data-title="<!-- TODO: descrição — Blue Grotto -->">
@@ -364,12 +403,35 @@ Ficamos mais um pouco numa **balada latina ao lado**, que também tinha o cupom 
 
 <div class="section-header">
   <div class="section-num">07</div>
-  <div class="section-title-wrap"><h2>Dia 4 — Comino e a Blue Lagoon</h2></div>
+  <div class="section-title-wrap"><h2>Dia 4 — Comino, Blue Lagoon e Crystal Lagoon</h2></div>
 </div>
 
-Acordamos por volta das 13h — três horas depois da saída do passeio que tínhamos comprado. Prejuízo assumido, compramos outro na hora: **€ 40 pelo Booking**, saindo de Sliema às 15h e voltando às 20h30.
+Só saímos do hotel às 14h43 — quase seis horas depois da saída do passeio que tínhamos comprado. Prejuízo assumido, compramos outro na hora: **€ 40 pelo Booking**, com saída de Sliema no início da tarde.
 
-Chegamos a Sliema quase em cima da hora (**Bolt: € 15**) e embarcamos num **ferry de dois andares**, com bar e mesas no térreo e cadeiras no primeiro piso. A travessia até Comino leva cerca de **1 hora**.
+### O passeio que perdemos × o passeio que fizemos
+
+Vale comparar os dois, porque a diferença é instrutiva:
+
+<table class="compare-table">
+  <thead>
+    <tr><th></th><th>Perdido — GetYourGuide (€ 26)</th><th>Feito — Booking (€ 40)</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Horário</td><td>09h00 → 14h30 (5h30)</td><td>15h04 → 20h18 (5h15)</td></tr>
+    <tr><td>Saída</td><td>San Pawl il-Baħar</td><td>Sliema</td></tr>
+    <tr><td>Blue Lagoon</td><td>≈ 1 hora</td><td>1h30, com waterslide no barco</td></tr>
+    <tr><td>Gozo</td><td>≈ 2 horas para explorar</td><td>Não incluído</td></tr>
+    <tr><td>Grutas e formações rochosas</td><td>Visita às cavernas marinhas</td><td>Parada de 5–10 min, sem mergulho</td></tr>
+    <tr><td>Segunda parada de mergulho</td><td>—</td><td>Crystal Lagoon, 45–60 min</td></tr>
+    <tr><td>Extras</td><td>Comentário ao vivo em inglês, escadas de acesso ao mar, banheiro a bordo, transfer opcional em Gozo</td><td>Ferry de 2 andares com bar, mesas no térreo e cadeiras no piso superior</td></tr>
+  </tbody>
+</table>
+
+O passeio da manhã era **objetivamente mais completo** — mesma duração, € 14 mais barato e ainda incluía duas horas em Gozo. O da tarde compensou em tempo de água: 1h30 na Blue Lagoon contra 1 hora, mais os 45 a 60 minutos de mergulho na **Crystal Lagoon**, que o outro não tinha.
+
+### Na prática
+
+Saímos do hotel às 14h43 e embarcamos às 15h04. A travessia de Sliema até Comino, com a **Luzzu Cruises**, levou **1h15** (36,8 km). O barco era um **ferry de dois andares**, com bar e mesas no térreo e cadeiras no primeiro piso.
 
 <div class="callout callout-warn">
   <div class="callout-label">Comino exige ingresso gratuito com QR code</div>
@@ -377,18 +439,20 @@ Chegamos a Sliema quase em cima da hora (**Bolt: € 15**) e embarcamos num **fe
 </div>
 
 **A estrutura em Comino:**
-- Food trucks e bebidas (só compramos água: € 2)
+- Food trucks e bebidas — consumimos **€ 24** a bordo e na ilha ao longo da tarde (€ 8 às 15h36, € 4 às 18h50 e € 12 às 19h23)
 - Lockers para guardar pertences
 - Aluguel de cadeira **com guarda-sol incluso por € 10** — não pegamos
 - Dá para pular das pedras ou nadar na praia
 
-E o aviso mais importante: **é muito lotado, mesmo no horário da tarde**. Ficamos até as 18h15.
+E o aviso mais importante: **é muito lotado, mesmo no horário da tarde**. Ficamos das 16h19 às 19h20 — três horas exatas na região de Comino, contando as paradas do barco.
 
-Na volta, o barco fez **mais 2 paradas na região**, e em uma delas era possível pular na água. Ficamos até as 19h45 e chegamos a Sliema às 20h30.
+Na volta, o barco fez mais duas paradas: uma **rápida, de 5 a 10 minutos, apenas para observar as grutas e cavernas** — sem entrar na água — e outra na **Crystal Lagoon**, com 45 a 60 minutos para mergulho. Chegamos de volta a Sliema às 20h18.
 
 ### Sliema: souvenirs e o Asian Kingdom
 
-Passamos numa loja de souvenirs — gastei **€ 30** em lembrancinhas, 6 copinhos de shot e uma bermuda branca (que teria uso no dia seguinte).
+Às 20h48 passamos numa loja de souvenirs — gastei **€ 33,45** em lembrancinhas, 8 copinhos de shot (cerca de € 2,50 cada) e uma bermuda branca, que teria uso no dia seguinte.
+
+Um detalhe que só percebi depois: o ingresso da festa do branco do dia seguinte foi comprado **ainda durante o passeio de barco**, às 18h38, direto no MedAsia — **€ 16,50**, sendo € 15 de ingresso e € 1,50 de taxas.
 
 Jantamos no **Asian Kingdom**, ao lado do Burger King. O meu pedido:
 
@@ -401,7 +465,7 @@ Jantamos no **Asian Kingdom**, ao lado do Burger King. O meu pedido:
     <tr><td>Arroz frito com carne</td><td>€ 6,00</td></tr>
     <tr><td>Porção de batata frita</td><td>€ 4,00</td></tr>
     <tr><td>Coca-Cola Zero 500 ml</td><td>€ 6,10</td></tr>
-    <tr><td><strong>Total</strong></td><td><strong>€ 20,10</strong></td></tr>
+    <tr><td><strong>Total da conta</strong></td><td><strong>€ 21,30</strong></td></tr>
   </tbody>
 </table>
 
@@ -409,20 +473,20 @@ Os amigos pediram arroz frito com carne, rolinho primavera de pato (4 un.) e chi
 
 <div class="callout callout-tip">
   <div class="callout-label">Banheiro em Sliema: a dica que ninguém dá</div>
-  Entrando no <strong>Burger King</strong> e indo até o fundo, você sai dentro de um pequeno shopping com <strong>banheiro por € 1</strong>. Saindo do BK e virando à esquerda fica o Asian Kingdom. Guarde essa referência — na orla de Sliema, banheiro público é escasso.
+  Entrando no <strong>Burger King</strong> e indo até o fundo, você sai dentro de um pequeno shopping com <strong>banheiro por € 1</strong> (o meu foi às 21h05) — e a catraca aceita <strong>pagamento por aproximação</strong>, tanto NFC pelo celular quanto cartão contactless. Saindo do BK e virando à esquerda fica o Asian Kingdom. Guarde essa referência: na orla de Sliema, banheiro público é escasso.
 </div>
 
-Voltamos de táxi (**€ 12**), mas a rua estava fechada em St. Julian's, em frente à delegacia. Descemos a cerca de 400 m do hotel e resolvemos caminhar pelo caminho mais longo, passando pela baía de St. Julian's e pela frente de Paceville — uns 15 a 20 minutos de caminhada que acabaram valendo mais que a corrida.
+A volta rendeu história: às 22h06 pedi um Bolt de **€ 12,40** e o motorista **cancelou sem nunca aparecer**. Um amigo pediu o dele, que saiu praticamente pelo mesmo valor. E aí a rua estava fechada em St. Julian's, em frente à delegacia. Descemos a cerca de 400 m do hotel e resolvemos caminhar pelo caminho mais longo, passando pela baía de St. Julian's e pela frente de Paceville — uns 15 a 20 minutos de caminhada que acabaram valendo mais que a corrida.
 
 <div class="photo-gallery">
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-01.jpg" class="glightbox" data-gallery="malta-dia4" data-title="<!-- TODO: descrição — Blue Lagoon, Comino -->">
     <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-01.jpg" alt="<!-- TODO: legenda — Blue Lagoon -->">
   </a>
-  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-02.jpg" class="glightbox" data-gallery="malta-dia4" data-title="<!-- TODO: descrição — ferry para Comino -->">
-    <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-02.jpg" alt="<!-- TODO: legenda — ferry -->">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-02.jpg" class="glightbox" data-gallery="malta-dia4" data-title="<!-- TODO: descrição — Crystal Lagoon -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-02.jpg" alt="<!-- TODO: legenda — Crystal Lagoon -->">
   </a>
-  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-03.jpg" class="glightbox" data-gallery="malta-dia4" data-title="<!-- TODO: descrição — Sliema ao anoitecer -->">
-    <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-03.jpg" alt="<!-- TODO: legenda — Sliema -->">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-03.jpg" class="glightbox" data-gallery="malta-dia4" data-title="<!-- TODO: descrição — grutas e formações rochosas -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia4-03.jpg" alt="<!-- TODO: legenda — grutas -->">
   </a>
 </div>
 
@@ -430,36 +494,38 @@ Voltamos de táxi (**€ 12**), mas a rua estava fechada em St. Julian's, em fre
 
 <div class="section-header">
   <div class="section-num">08</div>
-  <div class="section-title-wrap"><h2>Dia 5 — Festa do Branco e Footloose</h2></div>
+  <div class="section-title-wrap"><h2>Dia 5 — Festa do Branco no Toy Room Beach Club e Footloose</h2></div>
 </div>
 
 O dia da despedida do grupo original — e o segundo mais caro da viagem.
 
 ### Toy Room Beach Club, Sliema (11h–19h)
 
-Festa do branco, das 11h às 19h. **Entrada: € 15** (aquela mesma que vinha inclusa no combo da Pacha e a gente não usou).
+Começamos o dia com café da manhã tardio no **Basic Foods and Drinks** (**€ 21,73** às 11h23) e seguimos para a festa do branco no **Toy Room Beach Club de Sliema** — que aparece no extrato como **MedAsia Playa** —, onde ficamos das 14h20 às 19h — a unidade praiana da mesma marca da Toy Room (by Pacha) de Paceville, mas um lugar completamente diferente. **Entrada: € 15** (a mesma festa que vinha inclusa no combo do promeoter no primeiro dia e a gente não usou).
 
-**Alugamos uma cama perto da piscina principal: € 35 por pessoa.** As amigas conseguiram uma espreguiçadeira gratuita cada uma, através de um segurança brasileiro com quem fizeram amizade — vale a menção, porque em Malta isso funciona mais do que parece.
+**Alugamos uma cama perto da piscina principal por € 35** — na hora quem pagou foi um amigo, e depois acertei com ele por Revolut.
+
+O consumo funciona por **pulseira recarregável**, como na Toy Room de Paceville. Recarreguei **€ 40 às 14h37 e € 20 às 17h05**, somando € 60 em bebida ao longo do dia. As amigas conseguiram uma espreguiçadeira gratuita cada uma, através de um segurança brasileiro com quem fizeram amizade — vale a menção, porque em Malta isso funciona mais do que parece.
 
 <div class="callout callout-warn">
   <div class="callout-label">Mesma marca, política de bebida oposta</div>
-  Na <strong>Toy Room de Paceville</strong>, whisky com energético saía por <strong>€ 5</strong> — a mistura já pronta, sem entregar a lata. No <strong>Toy Room Beach Club</strong>, o mesmo drink custava <strong>€ 10</strong>: € 5 da dose e € 5 do energético cobrado à parte, mas com a <strong>lata fechada entregue na mão</strong>. Mesma marca, dois modelos completamente diferentes. Confira como funciona antes de fazer a conta da noite.
+  Na <strong>Toy Room (by Pacha), em Paceville</strong>, whisky com energético saía por <strong>€ 5</strong> — a mistura já pronta, sem entregar a lata. No <strong>Toy Room Beach Club, em Sliema</strong>, o mesmo drink custava <strong>€ 10</strong>: € 5 da dose e € 5 do energético cobrado à parte, mas com a <strong>lata fechada entregue na mão</strong>. Mesma marca, dois modelos completamente diferentes. Confira como funciona antes de fazer a conta da noite.
 </div>
-
-Consumimos entre **€ 60 e € 80 por pessoa** em bebidas ao longo do dia.
 
 ### A noite: despedida e Footloose
 
-Saímos da festa às 19h e pegamos um táxi (**€ 10**). Na chegada a St. Julian's a rua estava fechada de novo, então descemos e seguimos a pé. No caminho encontramos **outra unidade do Asian Kingdom** e jantamos ali — dessa vez pedi noodle de carne no lugar do arroz frito, mesmo valor total de **€ 20,10**.
+Saímos da festa às 19h (**€ 15,30** de Bolt na volta). Na chegada a St. Julian's a rua estava fechada de novo, então descemos e seguimos a pé. No caminho encontramos **outra unidade do Asian Kingdom** e jantamos ali às 20h04 — dessa vez pedi noodle de carne no lugar do arroz frito, e a conta foi de **€ 23,30**.
 
 Um dos amigos voou de volta às 22h45. Eu e o outro fomos ao **Footloose** encontrar as polonesas que ele tinha conhecido no barco de Comino na véspera.
 
-**Footloose:**
-- Entrada **€ 20**, com direito a **2 bebidas** inclusas — na prática, € 10 de cover
-- Música latina, casa grande
-- Consumo extra: **≈ € 50**
+Antes, às 23h23 e 23h50, compramos bebida no **Shop Express Cy** — € 19 e € 10,96, quase € 30 em mojito e gin em lata. Voltarei a esse detalhe na seção 12, porque o horário importa.
 
-Elas eram cinco, do interior da Polônia, e quase não falavam inglês. Em determinado momento foram embora — e logo depois duas voltaram e ficaram até o fim da balada. Voltamos a pé para o hotel, a poucos metros dali.
+**Footloose:**
+- Entrada **€ 20** (à 00h05), com direito a **2 bebidas** inclusas — na prática, € 10 de cover
+- Música latina, casa grande
+- Consumo extra: **€ 47,30**, em quatro comandas entre 01h01 e 03h41 (€ 11,80 · € 8,90 · € 14,80 · € 11,80)
+
+Elas eram cinco, do interior da Polônia, e quase não falavam inglês. Em determinado momento foram embora — e logo depois duas voltaram e ficaram até o fim da balada. Voltamos a pé para o hotel, a poucos metros dali, com mais uma parada no Shop Express às 04h52 (**€ 7,84**).
 
 <div class="callout callout-tip">
   <div class="callout-label">A ironia da noite</div>
@@ -468,10 +534,10 @@ Elas eram cinco, do interior da Polônia, e quase não falavam inglês. Em deter
 
 <!-- Nota: eventos noturnos raramente rendem foto. Se não houver imagem, remova o bloco. -->
 <div class="photo-gallery">
-  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia5-01.jpg" class="glightbox" data-gallery="malta-dia5" data-title="<!-- TODO: descrição — Toy Room Beach Club -->">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia5-01.jpg" class="glightbox" data-gallery="malta-dia5" data-title="<!-- TODO: descrição — Toy Room Beach Club, Sliema -->">
     <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia5-01.jpg" alt="<!-- TODO: legenda — festa do branco -->">
   </a>
-  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia5-02.jpg" class="glightbox" data-gallery="malta-dia5" data-title="<!-- TODO: descrição — Toy Room Beach Club -->">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia5-02.jpg" class="glightbox" data-gallery="malta-dia5" data-title="<!-- TODO: descrição — Toy Room Beach Club, Sliema -->">
     <img src="{{ site.baseurl }}/assets/img/posts/malta-2026-dia5-02.jpg" alt="<!-- TODO: legenda — festa do branco -->">
   </a>
 </div>
@@ -483,25 +549,29 @@ Elas eram cinco, do interior da Polônia, e quase não falavam inglês. Em deter
   <div class="section-title-wrap"><h2>Dia 6 — Sliema, mal-entendidos e o jantar no UMI</h2></div>
 </div>
 
-Acordamos entre 12h30 e 13h. Como era o último dia do meu amigo, decidimos ir à praia. As meninas estavam em Golden Bay, disseram que só tinha criança por lá e que iriam para Sliema — que era exatamente onde eu já queria ir, por ser a mais próxima.
+Acordamos entre 12h30 e 13h. Como era o último dia do meu amigo, decidimos ir à praia. As amigas estavam em Golden Bay, disseram que só tinha criança por lá e que iriam para Sliema — que era exatamente onde eu já queria ir, por ser a mais próxima.
 
 E aí o dia virou uma sequência de mal-entendidos. Achei que elas já estivessem em Sliema quando ainda estavam em Golden Bay, e no caminho ainda passaram no shopping sem avisar.
 
-Fomos os dois de Bolt (**€ 10**). E aqui vale o aviso: **as praias de Sliema são rochosas**. Acabamos voltando na direção de St. Julian's a pé até achar uma pequena faixa de areia. Entramos, ficamos esperando e nada. Por volta das 15h30/16h desistimos e fomos comer no **Asian Kingdom de St. Julian's** — a terceira visita à rede em quatro dias, com o mesmo pedido da primeira vez (**€ 20,10**).
+Pegamos o Bolt (**€ 8,30**) até a praia rochosa logo depois do **Il-Fortizza**, em Sliema. E aqui vale o aviso: **as praias de Sliema são rochosas** — não há faixa de areia na maior parte da orla.
+
+Fomos andando na direção do Toy Room e constatamos que dali para a frente não havia mais praia nenhuma. Voltamos, passamos em frente ao Il-Fortizza de novo (dessa vez a pé) e entramos na água em **Exiles Bay**. Depois seguimos caminhando pela beira do mar até o **Asian Kingdom de St. Julian's** — a terceira visita à rede em quatro dias, com o mesmo pedido da primeira vez (**€ 19,80**, às 16h03).
+
+Somando tudo — descer do Bolt, a ida e volta a pé pela orla, o tempo esperando as amigas em Exiles Bay e a caminhada final até o restaurante —, foram **5,75 km em 1h44**, das 13h39 às 15h23. Cerca de 3,6 milhas.
+
+Pelo caminho comprei uma garrafa de água de 2 litros num truck de sorvete (**€ 2,50**, às 13h49) e, mais tarde, uma **sandália de € 9,99** às 15h25 — o chinelo que eu tinha comprado na ilha arrebentou. O substituto acabou ficando no ASTE quando fui embora.
 
 Voltamos ao hotel pensando em pegar a piscina, mas já eram quase 17h e estava na hora dele sair para o aeroporto. Acabamos ficando no quarto: eu dormi um pouco e ele arrumou a mala.
 
 ### UMI — Sushi & Asian Fusion
 
-À noite jantei no **UMI**, em St. Paul's Bay, com a Giovanna e as duas amigas de Dublin.
+À noite jantei no **UMI**, em St. Paul's Bay, com as amigas de Dublin e uma amiga delas que mora em Malta — chefe de cozinha, já morou em Dublin por cerca de dois anos, além de ter vivido na Itália e em outro país do leste europeu. Conhecemos ela na segunda-feira, durante a viagem, e ter alguém que mora na ilha muda completamente a perspectiva sobre onde comer.
 
-A Giovanna é chefe de cozinha, mora em Malta, é amiga delas e já morou em Dublin por cerca de dois anos, além de ter vivido na Itália e em outro país do leste europeu. Nos conhecemos na segunda-feira, durante a viagem — e ter alguém que mora na ilha muda a perspectiva sobre onde comer.
+A reserva foi feita na véspera, durante a festa do branco. A sugestão original dela era outro restaurante, mas não havia horário disponível até o dia 29, quando eu já teria voltado. Ficou o UMI, mesa para 4 às 20h — remanejada no dia para 21h30, e acabamos chegando lá por volta das 21h50. As meninas comeram pouco, já tinham almoçado tarde.
 
-O convite foi feito na véspera, durante a festa do branco. Ela chegou a sugerir outro restaurante, mas não havia horário disponível até o dia 29, quando eu já teria voltado. A reserva ficou no UMI para as 20h, mesa para 4. Na tarde seguinte acabou sendo remanejada para **21h30** — e o que era para ser um jantar a dois virou mesa de quatro. As meninas comeram pouco, já tinham almoçado tarde.
+**A conta ficou em € 113 pelos quatro** — o jantar mais caro da viagem, e o único momento em que gastamos com um restaurante de verdade em vez de fast-food ou delivery.
 
-**A conta: € 113 pelos quatro**, paga por mim. Foi o item mais caro da viagem depois dos voos e da hospedagem — mais caro que qualquer noite de balada.
-
-Depois do jantar caminhamos até o hotel das meninas e de lá peguei um Bolt, deixei a Giovanna em casa e segui para o ASTE (**€ 28**). A ida tinha custado **€ 34** — St. Paul's Bay fica no extremo oposto de St. Julian's, e essas duas corridas foram o transporte mais caro de toda a viagem.
+Depois do jantar caminhamos do UMI até o **Canifor Hotel**, onde elas estavam: **1,42 km em 27 minutos**, cerca de 0,9 milha. De lá peguei um Bolt para o ASTE à 00h05 (**€ 19,90**). A ida, às 21h13, tinha custado **€ 19,40** — St. Paul's Bay fica no extremo oposto de St. Julian's, e essas duas corridas foram as mais caras da viagem. Chegando ao hotel, ainda gastei **€ 5** no Basic Foods and Drinks à 00h29.
 
 <div class="photo-gallery">
   <a href="{{ site.baseurl }}/assets/img/posts/malta-2026-dia6-01.jpg" class="glightbox" data-gallery="malta-dia6" data-title="<!-- TODO: descrição — praia rochosa de Sliema -->">
@@ -519,13 +589,13 @@ Depois do jantar caminhamos até o hotel das meninas e de lá peguei um Bolt, de
   <div class="section-title-wrap"><h2>Dia 7 — O dia de não fazer nada</h2></div>
 </div>
 
-Tinha combinado de ir a **Valletta** com as meninas, mas fiquei no hotel dormindo. Depois peguei a piscina da cobertura, e à noite pedi **KFC (€ 20)** e fiquei assistindo série no quarto.
+Tinha combinado de ir a **Valletta** com as amigas, mas fiquei no hotel dormindo. Depois peguei a piscina da cobertura, e pedi **KFC duas vezes ao longo do dia — € 27,82 no total** — assistindo série no quarto.
 
-Todo mundo já tinha ido embora — elas voltaram para Dublin naquele dia, depois de passarem a manhã e a tarde em Valletta — e a Giovanna trabalhava até umas 23h.
+Todo mundo já tinha ido embora — elas voltaram para Dublin naquele dia, depois de passarem a manhã e a tarde em Valletta.
 
 <div class="callout callout-tip">
   <div class="callout-label">Reserve um dia de nada</div>
-  Este foi o dia mais barato da viagem: <strong>€ 20 no total</strong>, contra os € 217 do Dia 5. Depois de cinco dias de praia, Bolt e balada até de madrugada, um dia inteiro sem sair do hotel não é desperdício de viagem — é o que torna os outros sustentáveis. Se o seu roteiro tem 7 ou 8 dias, planeje um deles para não fazer absolutamente nada.
+  Este foi o dia mais barato da viagem: <strong>€ 32,82 no total</strong>, contra os € 244 do Dia 6. Depois de cinco dias de praia, Bolt e balada até de madrugada, um dia inteiro sem sair do hotel não é desperdício de viagem — é o que torna os outros sustentáveis. Se o seu roteiro tem 7 ou 8 dias, planeje um deles para não fazer absolutamente nada.
 </div>
 
 <div class="photo-gallery">
@@ -546,7 +616,9 @@ Todo mundo já tinha ido embora — elas voltaram para Dublin naquele dia, depoi
 
 Acordei pronto para o checkout e descobri que dava para estender a saída (originalmente 11h) por **€ 15 a hora, até as 13h**. Paguei **€ 30**, dormi até meio-dia, tomei banho, arrumei a mala e fiz o checkout.
 
-Fiquei sentado na recepção jogando no celular até por volta das 16h30/17h. Depois saí, tomei o **último sorvete da viagem** numa sorveteria de St. Julian's — **€ 6 por um copo com o equivalente a 3 bolas** — e peguei um **Bolt para o aeroporto: € 16**.
+Fiquei sentado na recepção jogando no celular até as 16h48. Depois saí e tomei o **último sorvete da viagem no RivaReno**, em St. Julian's, entre 16h50 e 17h05 — foram **duas compras de € 6**, um scoop de limone e outro de limone com salted caramel. De lá, **Bolt para o aeroporto: € 16**, 8,6 km em 15 minutos. Cheguei ao terminal às 17h20.
+
+No free shop do aeroporto gastei mais **€ 82,17**: três perfumes em promoção a € 20 cada e € 22,17 em Toblerone (dois pacotes na promoção, um deles de € 15).
 
 ### O voo de volta
 
@@ -554,7 +626,7 @@ O voo deveria decolar às 20h de Malta e pousar às 23h em Dublin. **Decolamos �
 
 <div class="callout callout-warn">
   <div class="callout-label">EU261: por que não deu direito a compensação</div>
-  Pela regulamentação europeia <strong>EU261</strong>, o que conta para compensação financeira <strong>não é o atraso na decolagem, e sim o atraso na chegada</strong> ao destino final — e o gatilho é de <strong>3 horas ou mais</strong>. Com 1h11 de atraso na chegada, o voo ficou bem abaixo do limite. A elegibilidade para compensação começa com um atraso na chegada de três horas ou mais, sujeita às demais condições do EU261.
+  Pela regulamentação europeia <strong>EU261</strong>, o que conta para compensação financeira <strong>não é o atraso na decolagem, e sim o atraso na chegada</strong> ao destino final — e o gatilho é de <strong>3 horas ou mais</strong>. Com 1h11 de atraso na chegada, o voo ficou bem abaixo do limite. Só teria gerado direito se tivéssemos pousado depois das 02h00.
 </div>
 
 <div class="photo-gallery">
@@ -570,14 +642,60 @@ O voo deveria decolar às 20h de Malta e pousar às 23h em Dublin. **Decolamos �
 
 <div class="section-header">
   <div class="section-num">12</div>
-  <div class="section-title-wrap"><h2>O que ficou de fora: Valletta, Gozo e Popeye Village</h2></div>
+  <div class="section-title-wrap"><h2>Comprar bebida em St. Julian's: existe um toque de recolher</h2></div>
 </div>
 
-Este roteiro tem uma lacuna deliberada, e é justo explicá-la: **não visitei Valletta, Gozo nem a Popeye Village** nesta viagem.
+Esta é a informação mais difícil de achar sobre Malta na internet, e a que mais atrapalha quem está economizando: **em St. Julian's, os mercadinhos são proibidos de vender bebida alcoólica das 21h às 4h da manhã.**
 
-Eu já conhecia os três da minha primeira ida a Malta, em **2022**, e preferi usar os 8 dias em lugares que ainda não tinha visto — daí a concentração em praias, no sudeste da ilha e em Comino.
+Não sei dizer se a regra vale em outras regiões da ilha — nas que frequentamos, foi o que observamos.
 
-**Se é a sua primeira vez em Malta, não repita esse recorte.** Os três são incontornáveis:
+Na prática, conseguimos comprar mesmo assim: numa noite cerveja, na outra mojito e gin em lata, **apenas conversando com os vendedores** e saindo com as latas escondidas em sacos de papel. Não é algo com que se deva contar, e obviamente depende inteiramente da boa vontade de quem está atendendo.
+
+Os extratos deixam isso documentado: no **Shop Express Cy** há compras às **23h23 (€ 19)**, **23h50 (€ 10,96)** e **04h52 (€ 7,84)** — as três dentro da janela em que a venda deveria estar bloqueada.
+
+<div class="callout callout-warn">
+  <div class="callout-label">Repare no horário — e em quem ele beneficia</div>
+  A proibição começa às <strong>21h</strong>, justamente quando a noite começa, e termina às <strong>4h</strong>, que é <em>exatamente</em> o horário em que as baladas de Paceville fecham e voltam a poder vender. Não é difícil imaginar de onde veio a pressão para essa regra existir. O efeito prático é que, se você quer beber a preço de mercado, <strong>compre antes das 21h</strong> — depois disso, a única opção legal é pagar € 5 a dose dentro das casas noturnas.
+</div>
+
+<div class="divider">· · ·</div>
+
+<div class="section-header">
+  <div class="section-num">13</div>
+  <div class="section-title-wrap"><h2>Traje de banho na rua é proibido — e isso vale até dentro do carro</h2></div>
+</div>
+
+Esta é a regra que mais pega turista desprevenido em Malta, e vale conhecer antes de embarcar: **circular em via pública vestindo apenas traje de banho é infração**.
+
+Não é folclore nem etiqueta local. A justiça maltesa já confirmou publicamente que andar só de roupa de banho em áreas públicas configura **infração criminal de menor gravidade** segundo o direito penal do país, com os tribunais avaliando cada caso individualmente. E a fiscalização vem apertando: várias localidades instalaram **placas com pictograma de biquíni e sunga riscados** e o texto "swimwear prohibited in public areas", em inglês e maltês — em Valletta, Sliema, Msida e partes de St. Julian's, inclusive **na própria orla das praias**.
+
+Vale também saber que **topless e nudismo são proibidos em todas as praias públicas e piscinas de hotel** em Malta, sem exceção para enseadas isoladas.
+
+<div class="callout callout-warn">
+  <div class="callout-label">O motorista do Bolt pediu para vestirmos a camiseta — dentro do carro</div>
+  <p>Na saída do Toy Room Beach Club, na quarta-feira, o motorista do Bolt <strong>nos pediu para colocar a camiseta antes de sair</strong>. O carro estava com as janelas fechadas e nós estávamos sentados dentro dele — mesmo assim, a preocupação dele era concreta: se a polícia visse passageiros sem camisa, ele poderia ser abordado.</p>
+  <p>Ou seja: a regra não é só sobre andar na calçada de sunga. Do ponto de vista de quem trabalha com transporte por app na ilha, ela alcança até o interior do veículo. Leve sempre uma camiseta na mochila de praia — não é exagero, é o que evita constrangimento na porta do beach club.</p>
+</div>
+
+<div class="callout callout-tip">
+  <div class="callout-label">Regra prática</div>
+  Traje de banho é para a água e para a areia. Saiu da faixa de praia — para pegar o carro, entrar num bar da orla, andar até o mercadinho — <strong>vista uma camiseta e um short por cima</strong>. Uma canga resolve para quem está de biquíni. É um gesto de dois segundos que elimina qualquer risco de abordagem e, honestamente, de desconforto alheio.
+</div>
+
+<div class="divider">· · ·</div>
+
+<div class="section-header">
+  <div class="section-num">14</div>
+  <div class="section-title-wrap"><h2>O que ficou de fora — e por dois motivos diferentes</h2></div>
+</div>
+
+Este roteiro tem lacunas evidentes, e elas têm duas explicações distintas.
+
+**Valletta, Mdina e a Popeye Village eu pulei por já conhecer** — visitei os três em maio de 2022, na minha primeira ida a Malta. Preferi usar os 8 dias em lugares que ainda não tinha visto, daí a concentração em praias, no sudeste da ilha e em Comino.
+
+**Gozo é outra história: eu simplesmente nunca fui.** Em três passagens por Malta — 2022, a escala do réveillon de 2026 e agora esta viagem — a ilha vizinha continua na lista. Esteve mais perto do que nunca desta vez, já que o passeio de barco que perdi por dormir demais incluía duas horas livres lá. É a lacuna que mais me incomoda deste relato.
+
+**Se é a sua primeira vez em Malta, não repita esse recorte.** Os quatro são incontornáveis:
 
 <div class="providers-grid">
   <div class="provider-card">
@@ -587,8 +705,13 @@ Eu já conhecia os três da minha primeira ida a Malta, em **2022**, e preferi u
   </div>
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-ship"></i> Gozo</div>
-    <div class="provider-detail">A ilha vizinha, mais rural, mais calma e com paisagem completamente diferente da ilha principal. Acessível por ferry a partir de Cirkewwa. Vários passeios de barco a Comino incluem Gozo no mesmo roteiro — inclusive, provavelmente, aquele que eu perdi.</div>
+    <div class="provider-detail">A ilha vizinha, mais rural, mais calma e com paisagem completamente diferente da ilha principal. Acessível por ferry a partir de Cirkewwa. Vários passeios de barco a Comino incluem Gozo no mesmo roteiro — inclusive aquele que eu perdi, que dava 2 horas livres na ilha. <strong>O único destes quatro que eu ainda não conheço.</strong></div>
     <div class="provider-price">Um dia inteiro, no mínimo</div>
+  </div>
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-chess-rook"></i> Mdina</div>
+    <div class="provider-detail">A antiga capital medieval, murada e quase sem carros — conhecida como "a cidade silenciosa". Fica no interior da ilha, num ponto alto com vista para boa parte de Malta. Visitei em 2022 e é provavelmente o lugar mais fotogênico do país.</div>
+    <div class="provider-price">Meio dia · Melhor no fim da tarde</div>
   </div>
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-film"></i> Popeye Village</div>
@@ -600,7 +723,52 @@ Eu já conhecia os três da minha primeira ida a Malta, em **2022**, e preferi u
 <div class="divider">· · ·</div>
 
 <div class="section-header">
-  <div class="section-num">13</div>
+  <div class="section-num">15</div>
+  <div class="section-title-wrap"><h2>Bônus: Malta em maio de 2022, a primeira vez</h2></div>
+</div>
+
+Como boa parte deste relato se apoia no que eu já conhecia da ilha, faz sentido mostrar de onde vem esse conhecimento.
+
+Minha primeira ida a Malta foi de **2 a 8 de maio de 2022**. Fiquei hospedado na casa de uma amiga que mora na ilha — e que continua morando lá até hoje. Foi uma viagem de perfil completamente diferente desta: menos praia e balada, mais os cartões-postais clássicos.
+
+**O que vi em 2022:**
+- **Blue Grotto**, dessa vez com o passeio de barco pelas grutas — que em 2026 eu perdi por chegar depois do horário das embarcações
+- **Popeye Village**, em Anchor Bay
+- **Valletta**, a capital
+- **Mdina**, a antiga capital medieval murada
+
+Maio é uma época bem diferente de agosto para conhecer Malta: temperatura mais amena, mar ainda frio para a maioria das pessoas, muito menos gente nos pontos turísticos e preços de hospedagem significativamente mais baixos. Se o seu objetivo é passeio histórico e caminhada, **maio ganha de agosto com folga**.
+
+<div class="photo-gallery">
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2022-01.jpg" class="glightbox" data-gallery="malta-2022" data-title="<!-- TODO: descrição — Blue Grotto, passeio de barco (2022) -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2022-01.jpg" alt="<!-- TODO: legenda — Blue Grotto 2022 -->">
+  </a>
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2022-02.jpg" class="glightbox" data-gallery="malta-2022" data-title="<!-- TODO: descrição — Popeye Village (2022) -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2022-02.jpg" alt="<!-- TODO: legenda — Popeye Village 2022 -->">
+  </a>
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2022-03.jpg" class="glightbox" data-gallery="malta-2022" data-title="<!-- TODO: descrição — Valletta (2022) -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2022-03.jpg" alt="<!-- TODO: legenda — Valletta 2022 -->">
+  </a>
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2022-04.jpg" class="glightbox" data-gallery="malta-2022" data-title="<!-- TODO: descrição — Mdina (2022) -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2022-04.jpg" alt="<!-- TODO: legenda — Mdina 2022 -->">
+  </a>
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2022-05.jpg" class="glightbox" data-gallery="malta-2022" data-title="<!-- TODO: descrição — Malta 2022 -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2022-05.jpg" alt="<!-- TODO: legenda — Malta 2022 -->">
+  </a>
+  <a href="{{ site.baseurl }}/assets/img/posts/malta-2022-06.jpg" class="glightbox" data-gallery="malta-2022" data-title="<!-- TODO: descrição — Malta 2022 -->">
+    <img src="{{ site.baseurl }}/assets/img/posts/malta-2022-06.jpg" alt="<!-- TODO: legenda — Malta 2022 -->">
+  </a>
+</div>
+
+<div class="callout callout-tip">
+  <div class="callout-label">Post completo a caminho</div>
+  A viagem de 2022 foi bem maior que Malta: incluiu também <strong>Porto, Madrid, Bologna e algumas horas em Mallorca</strong>. Vou contar tudo num post dedicado — <!-- TODO: adicionar link quando publicado -->.
+</div>
+
+<div class="divider">· · ·</div>
+
+<div class="section-header">
+  <div class="section-num">16</div>
   <div class="section-title-wrap"><h2>Clima: agosto em Malta é quente de verdade</h2></div>
 </div>
 
@@ -611,7 +779,7 @@ Isso tem consequências práticas que valem mais do que o número no termômetro
 - **A festa do Café del Mar é a céu aberto** e, mesmo começando às 20h, estava bem quente
 - **Golden Bay das 13h às 18h30** só é viável com guarda-sol — os € 5 não são luxo, são necessidade
 - **Dormir até meio-dia** deixou de ser preguiça e virou estratégia: as horas entre 12h e 16h são as piores para qualquer coisa ao ar livre, e foi exatamente nesse padrão que a viagem inteira se encaixou
-- A água do mar estava excelente em todos os pontos — Golden Bay, St. Peter's Pool, Blue Grotto e Comino
+- A água do mar estava excelente em todos os pontos — Golden Bay, St. Peter's Pool, Blue Grotto, Blue Lagoon e Crystal Lagoon
 
 <div class="callout callout-tip">
   <div class="callout-label">O ritmo natural de Malta em agosto</div>
@@ -621,8 +789,8 @@ Isso tem consequências práticas que valem mais do que o número no termômetro
 <div class="divider">· · ·</div>
 
 <div class="section-header">
-  <div class="section-num">14</div>
-  <div class="section-title-wrap"><h2>Transporte: Bolt em vez de carro alugado</h2></div>
+  <div class="section-num">17</div>
+  <div class="section-title-wrap"><h2>Transporte: Bolt, e por que talvez valesse alugar carro</h2></div>
 </div>
 
 Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o ônibus TD2/TD3 na chegada). As corridas eram pedidas em esquema de rodízio: cada hora um do grupo chamava.
@@ -632,7 +800,7 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
     <tr><th>Dia</th><th>Trajeto</th><th>Total</th><th>Minha parte</th></tr>
   </thead>
   <tbody>
-    <tr><td>22/08</td><td>Aeroporto → St. Julian's (ônibus TD2/TD3)</td><td>€ 3,00</td><td>€ 3,00</td></tr>
+    <tr><td>22/08</td><td>Aeroporto → St. Julian's (ônibus TD3)</td><td>€ 3,00</td><td>€ 3,00</td></tr>
     <tr><td>23/08</td><td>Hotel → Golden Bay</td><td>€ 30,00</td><td>€ 10,00</td></tr>
     <tr><td>23/08</td><td>Golden Bay → Hotel</td><td>€ 30,40</td><td>€ 10,13</td></tr>
     <tr><td>23/08</td><td>Hotel → Café del Mar (Qawra)</td><td>€ 30,00</td><td>€ 10,00</td></tr>
@@ -640,33 +808,225 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
     <tr><td>24/08</td><td>Hotel → St. Peter's Pool</td><td>€ 30,00</td><td>€ 10,00</td></tr>
     <tr><td>24/08</td><td>St. Peter's → Marsaskala (van avulsa)</td><td>€ 20,00</td><td>€ 6,67</td></tr>
     <tr><td>24/08</td><td>Marsaskala → Blue Grotto</td><td>€ 15,00</td><td>€ 5,00</td></tr>
-    <tr><td>24/08</td><td>Blue Grotto → Hotel</td><td>€ 18,00</td><td>€ 6,00</td></tr>
-    <tr><td>25/08</td><td>Hotel → Sliema (ferry Comino)</td><td>€ 15,00</td><td>€ 5,00</td></tr>
-    <tr><td>25/08</td><td>Sliema → Hotel</td><td>€ 12,00</td><td>€ 4,00</td></tr>
+    <tr><td>24/08</td><td>Blue Grotto → Hotel (19h44–20h05)</td><td>€ 18,30</td><td>€ 6,10</td></tr>
+    <tr><td>25/08</td><td>Hotel → Sliema (ferry Comino)</td><td>€ 11,90</td><td>€ 3,97</td></tr>
+    <tr><td>25/08</td><td>Sliema → Hotel (após um Bolt cancelado de € 12,40)</td><td>≈ € 12,40</td><td>€ 4,13</td></tr>
     <tr><td>26/08</td><td>Hotel → Toy Room Beach Club</td><td>€ 12,00</td><td>€ 4,00</td></tr>
-    <tr><td>26/08</td><td>Beach Club → Hotel</td><td>€ 10,00</td><td>€ 3,33</td></tr>
-    <tr><td>27/08</td><td>Hotel → praia em Sliema</td><td>€ 10,00</td><td>€ 5,00</td></tr>
-    <tr><td>27/08</td><td>Hotel → Giovanna → UMI (St. Paul's Bay)</td><td>€ 34,00</td><td>€ 34,00</td></tr>
-    <tr><td>27/08</td><td>Hotel das amigas → Giovanna → ASTE</td><td>€ 28,00</td><td>€ 28,00</td></tr>
+    <tr><td>26/08</td><td>Beach Club → Hotel</td><td>€ 15,30</td><td>€ 5,10</td></tr>
+    <tr><td>27/08</td><td>Hotel → praia em Sliema</td><td>€ 8,30</td><td>€ 4,15</td></tr>
+    <tr><td>27/08</td><td>St. Julian's → St. Paul's Bay (UMI)</td><td>€ 19,40</td><td>€ 19,40</td></tr>
+    <tr><td>27/08</td><td>Canifor Hotel → ASTE</td><td>€ 19,90</td><td>€ 19,90</td></tr>
     <tr><td>29/08</td><td>St. Julian's → Aeroporto</td><td>€ 16,00</td><td>€ 16,00</td></tr>
-    <tr><td><strong>Total</strong></td><td></td><td><strong>€ 343,40</strong></td><td><strong>€ 170,13</strong></td></tr>
+    <tr><td><strong>Total</strong></td><td></td><td><strong>€ 321,90</strong></td><td><strong>€ 147,55</strong></td></tr>
   </tbody>
 </table>
 
+### O que diz a lei maltesa sobre dirigir e beber
+
+Antes de decidir por carro ou app, vale conhecer os números — e eles são mais apertados do que a fama de Malta sugere.
+
+Por muito tempo o país teve **o limite mais alto da Europa**, de 0,8 g/l, empatado com o Reino Unido. Isso mudou: hoje o limite é de **0,5 g/l de álcool no sangue** (equivalente a 22 microgramas por 100 ml de ar expirado) para motoristas comuns.
+
+<table class="compare-table">
+  <thead>
+    <tr><th>Categoria de motorista</th><th>Limite</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Motorista comum</td><td>0,5 g/l</td></tr>
+    <tr><td>Habilitação provisória (menos de 2 anos) e veículos comerciais</td><td>0,2 g/l</td></tr>
+    <tr><td>Ônibus, vans e transporte de passageiros</td><td>0,0 g/l — tolerância zero</td></tr>
+  </tbody>
+</table>
+
+Para dar dimensão prática: segundo material de campanha divulgado por médicos ligados à segurança viária em Malta, **duas doses padrão já colocam um homem de 70 kg no limite** dos 0,5 g/l — e **uma única dose** basta para estourar o limite de 0,2 g/l aplicável a habilitação provisória e veículos comerciais. Para mulheres do mesmo peso, a tolerância é menor ainda.
+
+A polícia tem autoridade para **parar e aplicar o bafômetro** em quem suspeitar estar acima do limite, com segundo teste na sede em caso de resultado positivo. As penalidades incluem suspensão da habilitação, pontos na carteira, multa e, em casos graves, pena privativa de liberdade.
+
 <div class="callout callout-warn">
-  <div class="callout-label">O transporte custou o mesmo que a passagem aérea</div>
-  O gasto total do grupo com transporte foi de <strong>€ 343,40</strong> — praticamente o mesmo valor da minha passagem Dublin–Malta ida e volta (€ 283). Com um roteiro espalhado pela ilha, o app de transporte deixa de ser detalhe e vira uma linha significativa do orçamento. Vale simular: <strong>um carro alugado por 7 dias em Malta sai por € 200–300</strong>, o que teria sido competitivo — com a ressalva de que ninguém dirige depois de uma noite em Paceville, e boa parte dos nossos deslocamentos foi exatamente nessa condição.
+  <div class="callout-label">Não existe "lei seca" de venda — existe restrição de horário</div>
+  <p>Malta <strong>não tem</strong> uma "lei seca" no sentido brasileiro (tolerância zero de álcool para todo motorista). O limite é de 0,5 g/l, e ele é aferido no bafômetro — não é a mera ingestão que configura a infração.</p>
+  <p>O que existe, como descrito na seção anterior, é a <strong>restrição de horário para venda de bebida em mercadinhos</strong> — coisa completamente diferente, e que atinge o consumidor, não o motorista.</p>
+  <p>Na prática, para quem vai passar a noite em Paceville, a conta é simples: <strong>duas cervejas e você já está no limite</strong>. Não vale o risco.</p>
 </div>
 
+### Bolt × carro alugado: a conta que eu faria de novo
+
+A decisão de não alugar carro foi tomada por um motivo específico: **partimos do princípio de que beberíamos em todas as situações** — o que, sendo honesto, não estava longe da verdade.
+
+Mas em vários momentos da viagem voltamos a cogitar o aluguel, nem que fosse por **um único dia**. E revendo os números, a ideia se sustenta:
+
+- O aluguel de carro em Malta é **barato** — bem mais barato do que o equivalente na Irlanda
+- O Bolt também é barato **em comparação com Dublin**, mas o total do grupo chegou a **€ 321,90**
+- O esquema de motorista da rodada seria viável: em vários dias um de nós **não estava bebendo**, ou bebia uma ou duas cervejas que poderiam ser dispensadas — e, com o limite de 0,5 g/l, dispensar mesmo é a única opção segura
+- Um carro teria resolvido situações específicas que o app complicou: a espera de 20 minutos em Marsaskala, o motorista que recusou a corrida na Blue Grotto, e a liberdade de encaixar uma quarta parada no Dia 3
+
 <div class="callout callout-tip">
+  <div class="callout-label">Veredito: considere o carro, mas o Bolt não é erro</div>
+  <p><strong>Vale a pena considerar alugar um carro</strong> — sobretudo para os dias de roteiro espalhado, como o do sudeste da ilha. Um único dia de aluguel já resolveria St. Peter's Pool, Marsaskala e Blue Grotto com folga, e provavelmente por menos do que os € 83,30 que o grupo gastou de app naquele dia.</p>
+  <p>Dito isso, <strong>o Bolt também é uma excelente opção</strong>: cobertura ampla, inclusive nos pontos afastados, preço razoável e nenhuma preocupação com estacionamento, combustível ou com quem vai dirigir na volta da balada. As duas escolhas são defensáveis — o erro seria não fazer a conta.</p>
+</div>
+
+<div class="callout callout-warn">
   <div class="callout-label">O preço do Bolt oscila muito</div>
-  O mesmo trajeto Hotel ↔ Sliema custou <strong>€ 15 na ida e € 12 na volta</strong>. A corrida recusada na Blue Grotto era <strong>€ 30</strong>; a seguinte, idêntica, saiu por <strong>€ 18</strong>. Se o preço parecer alto, cancele e peça de novo em alguns minutos.
+  O trajeto Hotel ↔ Sliema custou <strong>€ 11,90 num dia e € 8,30 no outro</strong>. A corrida recusada na Blue Grotto era <strong>€ 30</strong>; a seguinte, idêntica, saiu por <strong>€ 18,30</strong>. Se o preço parecer alto, cancele e peça de novo em alguns minutos.
 </div>
 
 <div class="divider">· · ·</div>
 
 <div class="section-header">
-  <div class="section-num">15</div>
+  <div class="section-num">18</div>
+  <div class="section-title-wrap"><h2>Custos — os gráficos da viagem</h2></div>
+</div>
+
+O total da viagem foi de **€ 2.143,02**, ou **€ 1.174,34 sem contar voos e hospedagem**. Antes das tabelas, os dois gráficos que mostram melhor onde o dinheiro foi.
+
+### Gasto por dia
+
+<div style="margin: 2rem 0; font-size: 0.9rem;">
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 1 · 22/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 56.7% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 105,50</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 2 · 23/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 14.6% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 208,26</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 3 · 24/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 57.2% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 104,27</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 4 · 25/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 30.1% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 170,35</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 5 · 26/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 18.4% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 199,09</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 6 · 27/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 243,88</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 7 · 28/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 86.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 32,82</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem;">
+    <div style="flex: 0 0 6.5rem; opacity: 0.75;">Dia 8 · 29/08</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 54.8% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 5.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 110,17</div>
+  </div>
+  <p style="opacity: 0.6; font-size: 0.8rem; margin-top: 0.75rem;">Gastos diários por pessoa, sem voos e hospedagem. Total: € 1.174,34.</p>
+</div>
+
+### Gasto por categoria
+
+<div style="margin: 2rem 0; font-size: 0.9rem;">
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Hospedagem</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 0% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 685,68 · 32%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Alimentação</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 49.6% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 345,65 · 16%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Festas e bebidas</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 49.9% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 343,53 · 16%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Voos</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 58.7% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 283,00 · 13%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Transporte</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 78.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 147,55 · 7%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Praia e beach club</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 78.9% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 145,00 · 7%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.6rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Compras e outros</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 81.5% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 126,61 · 6%</div>
+  </div>
+  <div style="display: flex; align-items: center; gap: 0.75rem;">
+    <div style="flex: 0 0 9rem; opacity: 0.75;">Passeios</div>
+    <div style="flex: 1; background: currentColor; opacity: 0.12; height: 1.4rem; border-radius: 3px; position: relative;"><div style="position: absolute; inset: 0 90.4% 0 0; background: currentColor; border-radius: 3px;"></div></div>
+    <div style="flex: 0 0 7.5rem; text-align: right; font-variant-numeric: tabular-nums;">€ 66,00 · 3%</div>
+  </div>
+  <p style="opacity: 0.6; font-size: 0.8rem; margin-top: 0.75rem;">Total por pessoa: € 2.143,02.</p>
+</div>
+
+### Tabela completa por categoria
+
+<table class="compare-table">
+  <thead>
+    <tr><th>Categoria</th><th>Total/pessoa</th><th>% do total</th><th>Por dia (8 dias)</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Hospedagem (7 noites + late checkout)</td><td>€ 685,68</td><td>32,0%</td><td>≈ € 97,95/noite</td></tr>
+    <tr><td>Alimentação</td><td>€ 345,65</td><td>16,1%</td><td>≈ € 43,21/dia</td></tr>
+    <tr><td>Festas, entradas e bebidas noturnas</td><td>€ 343,53</td><td>16,0%</td><td>≈ € 42,94/dia</td></tr>
+    <tr><td>Voos (Kiwi, ida e volta)</td><td>€ 283,00</td><td>13,2%</td><td>—</td></tr>
+    <tr><td>Transporte (Bolt, táxis e ônibus)</td><td>€ 147,55</td><td>6,9%</td><td>≈ € 18,44/dia</td></tr>
+    <tr><td>Praia e beach club (cadeiras, cama, consumo)</td><td>€ 145,00</td><td>6,8%</td><td>—</td></tr>
+    <tr><td>Compras e outros (souvenirs, free shop, sandália, banheiro)</td><td>€ 126,61</td><td>5,9%</td><td>—</td></tr>
+    <tr><td>Passeios (Comino € 40 + passeio perdido € 26)</td><td>€ 66,00</td><td>3,1%</td><td>—</td></tr>
+    <tr><td><strong>Total da viagem</strong></td><td><strong>€ 2.143,02</strong></td><td><strong>100%</strong></td><td><strong>≈ € 268/dia</strong></td></tr>
+    <tr><td><strong>Total sem voos e hospedagem</strong></td><td><strong>€ 1.174,34</strong></td><td>—</td><td><strong>≈ € 147/dia</strong></td></tr>
+  </tbody>
+</table>
+
+### Tabela completa por dia
+
+<table class="compare-table">
+  <thead>
+    <tr><th>Dia</th><th>Data</th><th>Principal responsável pelo valor</th><th>Gasto/pessoa</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Dia 1</td><td>22/08 (Sáb)</td><td>Duas festas na mesma noite (Society + Toy Room)</td><td>€ 105,50</td></tr>
+    <tr><td>Dia 2</td><td>23/08 (Dom)</td><td>Praia + duas festas + € 74,80 só de bebida</td><td>€ 208,26</td></tr>
+    <tr><td>Dia 3</td><td>24/08 (Seg)</td><td>Quatro corridas de Bolt (€ 27,77) + pizza + duas baladas</td><td>€ 104,27</td></tr>
+    <tr><td>Dia 4</td><td>25/08 (Ter)</td><td>Dois passeios pagos (€ 66) + souvenirs + consumo no barco</td><td>€ 170,35</td></tr>
+    <tr><td>Dia 5</td><td>26/08 (Qua)</td><td>Beach club completo (€ 111,50) + bebida de mercado + Footloose</td><td>€ 199,09</td></tr>
+    <tr><td>Dia 6</td><td>27/08 (Qui)</td><td>Jantar no UMI (€ 113) + € 39,30 de Bolt para St. Paul's Bay</td><td>€ 243,88</td></tr>
+    <tr><td>Dia 7</td><td>28/08 (Sex)</td><td>Só KFC (duas vezes)</td><td>€ 32,82</td></tr>
+    <tr><td>Dia 8</td><td>29/08 (Sáb)</td><td>Free shop do aeroporto (€ 82,17) + sorvete + Bolt</td><td>€ 110,17</td></tr>
+    <tr><td><strong>Total</strong></td><td></td><td></td><td><strong>€ 1.174,34</strong></td></tr>
+  </tbody>
+</table>
+
+<div class="callout callout-warn">
+  <div class="callout-label">Onde o dinheiro realmente foi</div>
+  <p><strong>Hospedagem foi um terço de todo o orçamento</strong> — e quase metade disso veio das duas últimas noites sozinho (€ 319,85 por 2 noites, contra € 268,33 por 4 noites dividindo o triplo).</p>
+  <p><strong>Alimentação e festas empataram em € 344 cada</strong>, e cada uma sozinha superou a passagem aérea. Somadas, dão o dobro dos voos.</p>
+  <p>O dia mais caro (€ 244) foi <strong>sete vezes</strong> mais caro que o mais barato (€ 33). E o último dia, em que eu só tomei sorvete e peguei um Bolt, custou € 110 por causa do free shop — vale lembrar do duty free na hora de fechar o orçamento.</p>
+</div>
+
+<div class="callout callout-tip">
+  <div class="callout-label">Quanto custaria uma versão mais econômica</div>
+  Com as mesmas 7 noites, mas dividindo quarto o tempo todo (≈ € 470 em vez de € 685), sem os € 26 do passeio perdido, sem os € 82 do free shop e com consumo noturno moderado (≈ € 150 em vez de € 343), a mesma viagem sairia por <strong>≈ € 1.630</strong>, ou <strong>≈ € 1.347 sem os voos</strong>. Malta não é um destino barato como a Albânia, mas também não precisa custar € 2.140.
+</div>
+
+<div class="divider">· · ·</div>
+
+<div class="section-header">
+  <div class="section-num">19</div>
   <div class="section-title-wrap"><h2>Galeria de fotos</h2></div>
 </div>
 
@@ -694,7 +1054,7 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
 <div class="divider">· · ·</div>
 
 <div class="section-header">
-  <div class="section-num">16</div>
+  <div class="section-num">20</div>
   <div class="section-title-wrap"><h2>Locais — preços e avaliações</h2></div>
 </div>
 
@@ -714,20 +1074,56 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-house-flag"></i> Marsaskala</div>
-    <div class="provider-detail">Praia muito pequena e público predominantemente familiar. Não agradou ao nosso perfil de viagem. A espera pelo Bolt na região foi longa (20 minutos).</div>
+    <div class="provider-detail">Faixa de areia pequena, público predominantemente familiar e área de mergulho tomada por barcos. Há restaurante na frente da praia, que não chegamos a testar. Espera longa pelo Bolt na região.</div>
     <div class="provider-price">Nota 4/10 para grupo de amigos · Melhor para famílias</div>
   </div>
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-water"></i> Blue Grotto</div>
-    <div class="provider-detail">Sem praia e com água funda — entrada direto do costão. Chegando depois das 18h os barcos de passeio já pararam e o lugar fica quase vazio, o que muda completamente a experiência.</div>
+    <div class="provider-detail">Sem praia e com água funda — entrada direto do costão. Depois das 18h os barcos de passeio param, mas o local continua movimentado (80 a 100 pessoas quando chegamos). Nadar entre as embarcações ancoradas é a experiência.</div>
     <div class="provider-price">Acesso gratuito · Ideal a partir das 18h</div>
   </div>
 
   <div class="provider-card">
-    <div class="provider-name"><i class="fas fa-island-tropical"></i> Blue Lagoon — Comino</div>
+    <div class="provider-name"><i class="fas fa-water"></i> Blue Lagoon — Comino</div>
     <div class="provider-detail">Ingresso gratuito obrigatório com QR code pelo site blcomino.com. Food trucks, bar e lockers no local. Dá para pular das pedras ou nadar na praia. Muito lotado mesmo no fim da tarde.</div>
     <div class="provider-price">Entrada gratuita (QR) · Cadeira com guarda-sol € 10</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-person-swimming"></i> Crystal Lagoon</div>
+    <div class="provider-detail">Segunda parada de mergulho do passeio da tarde, com 45 a 60 minutos na água. Não estava incluída no passeio matinal — foi o que compensou a troca de horário.</div>
+    <div class="provider-price">Incluída no passeio de barco</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-water"></i> Exiles Bay — Sliema</div>
+    <div class="provider-detail">Ponto de banho na orla rochosa de Sliema, depois do Il-Fortizza. Da faixa que fica logo após o Il-Fortizza em direção ao Toy Room não há mais praia — vale entrar na água em Exiles e seguir a pé pela orla até St. Julian's.</div>
+    <div class="provider-price">Acesso gratuito · Orla rochosa, sem areia</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-ship"></i> Luzzu Cruises</div>
+    <div class="provider-detail">Operadora do passeio de barco que fizemos, com saída de Sliema. Ferry de dois andares com bar e mesas no térreo. Roteiro com Blue Lagoon, parada nas grutas e mergulho na Crystal Lagoon.</div>
+    <div class="provider-price">€ 40 pelo Booking · Consumo a bordo € 24</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-record-vinyl"></i> Flow Club — Paceville</div>
+    <div class="provider-detail">Balada de reggaeton em Paceville, com entrada gratuita e cupom de compre 1 leve 2 (uso único) na bebida.</div>
+    <div class="provider-price">Entrada gratuita · Rodada € 5,40</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-record-vinyl"></i> Qube Club — Paceville</div>
+    <div class="provider-detail">Ao lado do Flow Club, com música latina. Também tinha o cupom de pague 1 leve 2 na primeira rodada.</div>
+    <div class="provider-price">Rodada € 5,90</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-mug-saucer"></i> Basic Foods and Drinks — St. Julian's</div>
+    <div class="provider-detail">Onde acabamos fazendo o café da manhã tardio que substituiu o do hotel, e onde parei de madrugada na volta do jantar. Perto do ASTE.</div>
+    <div class="provider-price">Refeição € 21,73 · Parada rápida € 5</div>
   </div>
 
   <div class="provider-card">
@@ -739,25 +1135,43 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-pizza-slice"></i> Claudio's Pizza — St. Julian's</div>
     <div class="provider-detail">Em frente ao ASTE Hotel. Pizzas grandes — a maioria das pessoas não termina uma sozinha. Fazem embalagem para viagem.</div>
-    <div class="provider-price">€ 57 (3 pizzas + 4 refrigerantes) · ≈ € 19/pessoa</div>
+    <div class="provider-price">€ 58 (3 pizzas + 4 refrigerantes) · ≈ € 19,33/pessoa</div>
   </div>
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-bowl-rice"></i> Asian Kingdom</div>
     <div class="provider-detail">Rede com unidades em Sliema (ao lado do Burger King) e em St. Julian's. Cardápio enorme entre chinês, japonês e tailandês. Fomos três vezes em quatro dias — porção grande e preço justo. Atenção ao refrigerante, mais caro que vários pratos.</div>
-    <div class="provider-price">Prato principal € 6–12 · Refrigerante 500 ml € 6,10 · Conta ≈ € 20/pessoa</div>
+    <div class="provider-price">Prato principal € 6–12 · Refrigerante 500 ml € 6,10 · Contas de € 19,80 a € 23,30</div>
   </div>
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-fish"></i> UMI — Sushi & Asian Fusion</div>
-    <div class="provider-detail">Restaurante japonês em St. Paul's Bay (43 Bognor). Aceita reserva online com confirmação por mensagem. Recomendação de quem mora na ilha. Foi o jantar mais caro da viagem.</div>
+    <div class="provider-detail">Restaurante japonês em St. Paul's Bay (43 Bognor). Aceita reserva online com confirmação e alteração por mensagem. Recomendação de quem mora na ilha. Foi o jantar mais caro da viagem.</div>
     <div class="provider-price">€ 113 para 4 pessoas · ≈ € 28/pessoa</div>
   </div>
 
   <div class="provider-card">
-    <div class="provider-name"><i class="fas fa-champagne-glasses"></i> Pacha / Toy Room — Paceville</div>
-    <div class="provider-detail">Público jovem (17–25 anos), muito estudante e turista italiano. Sistema de pulseira recarregável. Fecha às 04h. Área VIP num nível acima da pista.</div>
+    <div class="provider-name"><i class="fas fa-ice-cream"></i> RivaReno — St. Julian's</div>
+    <div class="provider-detail">Sorveteria em St. Julian's. Scoops de limone e salted caramel. Foi a última parada antes de pegar o Bolt para o aeroporto.</div>
+    <div class="provider-price">€ 6 por scoop</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-champagne-glasses"></i> Society Hotel (rooftop) — Paceville</div>
+    <div class="provider-detail">Pool party no rooftop do hotel, encerrando às 23h — encaixa perfeitamente antes das baladas, que só enchem depois da meia-noite. Consumo no mesmo padrão da ilha.</div>
+    <div class="provider-price">Entrada € 20 · Dose/bebida € 5 · ≈ € 15–20/pessoa em consumo</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-record-vinyl"></i> Toy Room (by Pacha) — Paceville</div>
+    <div class="provider-detail">A casa noturna de Paceville — não confundir com o Toy Room Beach Club de Sliema. Público jovem (17–25 anos), muito estudante e turista italiano. Pulseira recarregável. Fecha às 04h. Área VIP num nível acima da pista.</div>
     <div class="provider-price">Entrada € 25 (promoter) · VIP € 50 · Pulseira € 20 = 4 drinks</div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-umbrella-beach"></i> Toy Room Beach Club — Sliema</div>
+    <div class="provider-detail">A unidade praiana da marca, em Sliema (aparece no extrato como <em>MedAsia Playa</em>) — lugar completamente diferente da casa de Paceville. Festa diurna, camas próximas à piscina principal e espreguiçadeiras. Consumo por pulseira recarregável. Energético cobrado à parte, mas com a lata fechada entregue.</div>
+    <div class="provider-price">Entrada € 16,50 (com taxas) · Cama € 35 · Pulseira recarregável · Dose € 5 (+ € 5 energético)</div>
   </div>
 
   <div class="provider-card">
@@ -773,15 +1187,9 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
   </div>
 
   <div class="provider-card">
-    <div class="provider-name"><i class="fas fa-umbrella-beach"></i> Toy Room Beach Club — Sliema</div>
-    <div class="provider-detail">Festa diurna (11h–19h). Camas próximas à piscina principal e espreguiçadeiras. Energético cobrado à parte, mas com a lata fechada entregue — diferente da casa de Paceville.</div>
-    <div class="provider-price">Entrada € 15 · Cama € 35/pessoa · Dose € 5 (+ € 5 energético)</div>
-  </div>
-
-  <div class="provider-card">
     <div class="provider-name"><i class="fas fa-record-vinyl"></i> Footloose — Paceville</div>
     <div class="provider-detail">Música latina, casa grande. A entrada inclui 2 bebidas, o que na prática reduz o cover a € 10.</div>
-    <div class="provider-price">Entrada € 20 (2 bebidas inclusas)</div>
+    <div class="provider-price">Entrada € 20 (2 bebidas inclusas) · Consumo extra € 47,30</div>
   </div>
 
 </div>
@@ -789,67 +1197,7 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
 <div class="divider">· · ·</div>
 
 <div class="section-header">
-  <div class="section-num">17</div>
-  <div class="section-title-wrap"><h2>Custos — resumo por categoria</h2></div>
-</div>
-
-<table class="compare-table">
-  <thead>
-    <tr>
-      <th>Categoria</th>
-      <th>Total/pessoa</th>
-      <th>Por dia (8 dias)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr><td>Voos (Kiwi, ida e volta)</td><td>€ 283,00</td><td>—</td></tr>
-    <tr><td>Hospedagem (7 noites + late checkout)</td><td>€ 685,68</td><td>≈ € 97,95/noite</td></tr>
-    <tr><td>Transporte (Bolt, táxis e ônibus)</td><td>€ 170,13</td><td>≈ € 21,27/dia</td></tr>
-    <tr><td>Alimentação (almoços, jantares, sorvete)</td><td>€ 273,97</td><td>≈ € 34,25/dia</td></tr>
-    <tr><td>Festas, entradas e bebidas noturnas</td><td>€ 338,13</td><td>≈ € 42,27/dia</td></tr>
-    <tr><td>Praia (cadeiras, guarda-sóis, camas, consumo)</td><td>€ 85,00</td><td>—</td></tr>
-    <tr><td>Passeios (Comino € 40 + passeio perdido € 26)</td><td>€ 66,00</td><td>—</td></tr>
-    <tr><td>Souvenirs</td><td>€ 30,00</td><td>—</td></tr>
-    <tr><td><strong>Total da viagem</strong></td><td><strong>€ 1.931,91</strong></td><td><strong>≈ € 241/dia</strong></td></tr>
-    <tr><td><strong>Total sem voos e hospedagem</strong></td><td><strong>€ 963,23</strong></td><td><strong>≈ € 120/dia</strong></td></tr>
-  </tbody>
-</table>
-
-### Gasto por dia
-
-<table class="compare-table">
-  <thead>
-    <tr><th>Dia</th><th>Data</th><th>Gasto/pessoa</th></tr>
-  </thead>
-  <tbody>
-    <tr><td>Dia 1</td><td>22/08 (Sáb)</td><td>€ 68,00</td></tr>
-    <tr><td>Dia 2</td><td>23/08 (Dom)</td><td>€ 208,26</td></tr>
-    <tr><td>Dia 3</td><td>24/08 (Seg)</td><td>€ 100,34</td></tr>
-    <tr><td>Dia 4</td><td>25/08 (Ter)</td><td>€ 127,10</td></tr>
-    <tr><td>Dia 5</td><td>26/08 (Qua)</td><td>€ 217,43</td></tr>
-    <tr><td>Dia 6</td><td>27/08 (Qui)</td><td>€ 200,10</td></tr>
-    <tr><td>Dia 7</td><td>28/08 (Sex)</td><td>€ 20,00</td></tr>
-    <tr><td>Dia 8</td><td>29/08 (Sáb)</td><td>€ 22,00</td></tr>
-    <tr><td><strong>Total (sem voos e hospedagem)</strong></td><td></td><td><strong>€ 963,23</strong></td></tr>
-  </tbody>
-</table>
-
-<div class="callout callout-warn">
-  <div class="callout-label">Onde o dinheiro realmente foi</div>
-  <p><strong>Hospedagem foi 35% de todo o orçamento</strong> — e quase metade disso veio das duas últimas noites sozinho no quarto single (€ 319,85 por 2 noites, contra € 268,33 por 4 noites dividindo o triplo).</p>
-  <p><strong>Festas e bebidas somaram € 338,13 — mais que a passagem aérea.</strong> Se você cortar pela metade o consumo noturno, a viagem inteira cai para a faixa dos € 1.750.</p>
-  <p>O dia mais caro (€ 217) foi <strong>dez vezes</strong> mais caro que o mais barato (€ 20). A diferença entre os dois não foi passeio nem hospedagem: foi bebida e entrada de festa.</p>
-</div>
-
-<div class="callout callout-tip">
-  <div class="callout-label">Quanto custaria uma versão mais econômica</div>
-  Com as mesmas 7 noites, mas dividindo quarto o tempo todo (≈ € 470 em vez de € 685), sem os € 26 do passeio perdido e com consumo noturno moderado (≈ € 150 em vez de € 338), a mesma viagem sairia por <strong>≈ € 1.502</strong>, ou <strong>≈ € 1.219 sem os voos</strong>. Malta não é um destino barato como a Albânia, mas também não precisa custar € 1.900.
-</div>
-
-<div class="divider">· · ·</div>
-
-<div class="section-header">
-  <div class="section-num">18</div>
+  <div class="section-num">21</div>
   <div class="section-title-wrap"><h2>Links úteis</h2></div>
 </div>
 
@@ -857,7 +1205,13 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
 
   <div class="provider-card">
     <div class="provider-name"><i class="fas fa-hotel"></i> ASTE Hotel — St. Julian's</div>
-    <div class="provider-detail">Nosso hotel em St. Julian's. Quartos family com varanda, piscina na cobertura e café da manhã. A 5 minutos de St. George's Bay e na rua de baixo de Paceville. Oferece late checkout por hora.</div>
+    <div class="provider-detail">Nosso hotel em St. Julian's. Quartos family com varanda, piscina na cobertura e café da manhã. A 5 minutos de St. George's Bay e na rua de baixo de Paceville. Oferece late checkout por hora (€ 15/h até as 13h).</div>
+    <div class="provider-price"><!-- TODO: link do Booking / site do hotel --></div>
+  </div>
+
+  <div class="provider-card">
+    <div class="provider-name"><i class="fas fa-hotel"></i> Canifor Hotel — Buġibba</div>
+    <div class="provider-detail">Onde ficaram as amigas do grupo, de 23 a 28/08. Fica em Buġibba, no norte da ilha — 20 a 30 minutos de Bolt até St. Julian's.</div>
     <div class="provider-price"><!-- TODO: link do Booking / site do hotel --></div>
   </div>
 
@@ -865,12 +1219,6 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
     <div class="provider-name"><i class="fas fa-ticket"></i> Blue Lagoon Comino — ingresso obrigatório</div>
     <div class="provider-detail">Ingresso gratuito com QR code, obrigatório para entrar na Blue Lagoon. Retire antes de embarcar no ferry.</div>
     <div class="provider-price"><a href="https://blcomino.com" target="_blank">blcomino.com →</a></div>
-  </div>
-
-  <div class="provider-card">
-    <div class="provider-name"><i class="fas fa-music"></i> Sundays — Café del Mar</div>
-    <div class="provider-detail">Festa dominical no Café del Mar, em Qawra. Ingressos normais e VIP pelo site. Evento a céu aberto, das 20h à 01h.</div>
-    <div class="provider-price"><a href="https://sundays.com.mt" target="_blank">sundays.com.mt →</a></div>
   </div>
 
   <div class="provider-card">
@@ -893,9 +1241,35 @@ Não alugamos carro em nenhum momento — **usamos exclusivamente o Bolt** (e o 
 
 </div>
 
+<div class="references">
+  <p class="references-title">Referências — legislação citada</p>
+  <ol class="references-list">
+    <li>
+      The Malta Independent on Sunday. <strong>Legal limit slashed, now let's enforce it</strong> — redução do limite de 80 mg/dl para 50 mg/dl, 20 mg/dl para habilitação provisória e veículos comerciais, e zero para ônibus e transporte de passageiros.
+      <a href="https://www.pressreader.com/malta/the-malta-independent-on-sunday/20181223/281672551054768" target="_blank">independent.com.mt</a>
+    </li>
+    <li>
+      Newsbook. <strong>Caritas calls for random breathalyser testing</strong> — referência ao limite legal de 22 microgramas por 100 ml de ar expirado.
+      <a href="https://newsbook.com.mt/en/caritas-calls-for-random-breathalyser-testing-even-without-suspicion-of-intoxication/" target="_blank">newsbook.com.mt</a>
+    </li>
+    <li>
+      Angloinfo Malta. <strong>Penalties and Drink Driving</strong> — poder de fiscalização da polícia e penalidades aplicáveis.
+      <a href="https://www.angloinfo.com/how-to/malta/transport/driving/penalties-drink-driving" target="_blank">angloinfo.com</a>
+    </li>
+    <li>
+      The Malta Independent. <strong>Wearing nothing but swimwear in public is a minor criminal offence</strong> — posição do Ministério da Justiça de Malta.
+      <a href="https://www.independent.com.mt/articles/2019-08-10/local-news/Wearing-nothing-but-swimwear-in-public-is-a-minor-criminal-offence-but-is-it-enforced-6736212065" target="_blank">independent.com.mt</a>
+    </li>
+    <li>
+      GuideMeMalta. <strong>Maltese beach etiquette: the dos and don'ts</strong> — proibição de topless e nudismo nas praias públicas.
+      <a href="https://www.guidememalta.com/en/maltese-beach-etiquette-the-dos-and-don-ts" target="_blank">guidememalta.com</a>
+    </li>
+  </ol>
+</div>
+
 <div class="conclusion">
   <h2>Vale a pena — mas ajuste as expectativas de preço</h2>
-  <p>Malta entrega exatamente o que promete: água cristalina em praias completamente diferentes entre si, uma vida noturna concentrada e intensa em Paceville, distâncias curtas que permitem três lugares no mesmo dia, e tudo isso a menos de 4 horas de voo de Dublin. Em oito dias eu nadei numa praia de areia, numa piscina natural de rocha, numa gruta funda sem acesso por terra e na Blue Lagoon — e nenhuma delas se parecia com a outra.</p>
-  <p>Mas não é um destino barato. Ao contrário da Albânia, onde o custo-benefício é o argumento principal, em Malta você paga preço europeu por quase tudo: € 5,80 a cerveja, € 6,10 o refrigerante de 500 ml, € 160 a diária de um quarto single em agosto. O que salva o orçamento é dividir — quarto, corridas de Bolt, contas de restaurante. Sozinho, a mesma viagem fica desproporcionalmente cara.</p>
-  <p>Se eu fizesse de novo, mudaria três coisas: alinharia as datas com o resto do grupo para não pagar diária de single, colocaria Gozo no roteiro (nem que fosse repetindo) e não compraria passeio com saída às 9h da manhã depois de uma noite em Paceville. O resto eu repetiria exatamente igual.</p>
+  <p>Malta entrega exatamente o que promete: água cristalina em praias completamente diferentes entre si, uma vida noturna concentrada e intensa em Paceville, distâncias curtas que permitem três lugares no mesmo dia, e tudo isso a menos de 4 horas de voo de Dublin. Em oito dias eu nadei numa praia de areia, numa piscina natural de rocha, numa gruta funda sem acesso por terra, na Blue Lagoon e na Crystal Lagoon — e nenhuma delas se parecia com a outra.</p>
+  <p>Mas não é um destino barato. Ao contrário da Albânia, onde o custo-benefício é o argumento principal, em Malta você paga preço europeu por quase tudo: € 5,80 a cerveja, € 6,10 o refrigerante de 500 ml, € 160 a diária de um quarto single em agosto. O que salva o orçamento é dividir — quarto, corridas, contas de restaurante. Sozinho, a mesma viagem fica desproporcionalmente cara.</p>
+  <p>Se eu fizesse de novo, mudaria quatro coisas: alinharia as datas com o resto do grupo para não pagar diária de single, alugaria carro pelo menos no dia do roteiro do sudeste, finalmente conheceria Gozo, que já escapou três vezes e não compraria passeio com saída às 9h da manhã depois de uma noite em Paceville. O resto eu repetiria exatamente igual.</p>
 </div>

--- a/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
+++ b/_posts/2026-08-30-malta-st-julians-comino-roteiro-8-dias.md
@@ -56,14 +56,14 @@ A passagem foi comprada pelo **Kiwi** em 25/07/2026, um mês antes da viagem:
 
 <table class="compare-table">
   <thead>
-    <tr><th>Trecho</th><th>Data</th><th>Horário</th><th>Valor</th></tr>
+    <tr><th>Trecho</th><th>Data</th><th>Saída prevista</th><th>Saída real</th><th>Valor</th></tr>
   </thead>
   <tbody>
-    <tr><td>Dublin (DUB) → Manchester (MAN)</td><td>22/08</td><td>06h30</td><td>€ 25,85</td></tr>
-    <tr><td>Manchester (MAN) → Malta (MLA)</td><td>22/08</td><td>08h45</td><td>€ 94,82</td></tr>
-    <tr><td>Malta (MLA) → Dublin (DUB)</td><td>29/08</td><td>20h00</td><td>€ 133,48</td></tr>
-    <tr><td>Taxa de serviço Kiwi</td><td>—</td><td>—</td><td>€ 28,85</td></tr>
-    <tr><td><strong>Total</strong></td><td></td><td></td><td><strong>€ 283,00</strong></td></tr>
+    <tr><td>Dublin (DUB) → Manchester (MAN)</td><td>22/08</td><td>06h30</td><td>06h09</td><td>€ 25,85</td></tr>
+    <tr><td>Manchester (MAN) → Malta (MLA)</td><td>22/08</td><td>08h45</td><td>09h08</td><td>€ 94,82</td></tr>
+    <tr><td>Malta (MLA) → Dublin (DUB)</td><td>29/08</td><td>20h00</td><td>21h23</td><td>€ 133,48</td></tr>
+    <tr><td>Taxa de serviço Kiwi</td><td>—</td><td>—</td><td>—</td><td>€ 28,85</td></tr>
+    <tr><td><strong>Total</strong></td><td></td><td></td><td></td><td><strong>€ 283,00</strong></td></tr>
   </tbody>
 </table>
 
@@ -420,7 +420,7 @@ Vale comparar os dois, porque a diferença é instrutiva:
     <tr><th></th><th>Perdido — GetYourGuide (€ 26)</th><th>Feito — Booking (€ 40)</th></tr>
   </thead>
   <tbody>
-    <tr><td>Horário</td><td>09h00 → 14h30 (5h30)</td><td>15h04 → 20h18 (5h15)</td></tr>
+    <tr><td>Horário</td><td>09h00 → 14h30 (5h30 previstas)</td><td>15h04 → 20h18 (5h15 reais)</td></tr>
     <tr><td>Saída</td><td>San Pawl il-Baħar</td><td>Sliema</td></tr>
     <tr><td>Blue Lagoon</td><td>≈ 1 hora</td><td>1h30, com waterslide no barco</td></tr>
     <tr><td>Gozo</td><td>≈ 2 horas para explorar</td><td>Não incluído</td></tr>
@@ -430,7 +430,7 @@ Vale comparar os dois, porque a diferença é instrutiva:
   </tbody>
 </table>
 
-O passeio da manhã era **objetivamente mais completo** — mesma duração, € 14 mais barato e ainda incluía duas horas em Gozo. O da tarde compensou em tempo de água: 1h30 na Blue Lagoon contra 1 hora, mais os 45 a 60 minutos de mergulho na **Crystal Lagoon**, que o outro não tinha.
+O passeio da manhã era **objetivamente mais completo** — praticamente a mesma duração (5h30 previstas contra as 5h15 que o nosso levou na prática), cerca de € 14 mais barato por pessoa e ainda com duas horas em Gozo. O da tarde compensou em tempo de água: 1h30 na Blue Lagoon contra 1 hora, mais os 45 a 60 minutos de mergulho na **Crystal Lagoon**, que o outro não tinha.
 
 ### Na prática
 
@@ -702,7 +702,7 @@ Vale também saber que **topless e nudismo são proibidos em todas as praias pú
 <div class="callout callout-warn">
   <div class="callout-label">O motorista do Bolt pediu para vestirmos a camiseta — dentro do carro</div>
   <p>Na saída do Toy Room Beach Club, na quarta-feira, o motorista do Bolt <strong>nos pediu para colocar a camiseta antes de sair</strong>. O carro estava com as janelas fechadas e nós estávamos sentados dentro dele — mesmo assim, a preocupação dele era concreta: se a polícia visse passageiros sem camisa, ele poderia ser abordado.</p>
-  <p>Ou seja: a regra não é só sobre andar na calçada de sunga. Do ponto de vista de quem trabalha com transporte por app na ilha, ela alcança até o interior do veículo. Leve sempre uma camiseta na mochila de praia — não é exagero, é o que evita constrangimento na porta do beach club.</p>
+  <p>Vale a ressalva: a regra que citei acima trata de <strong>áreas públicas</strong>, e o pedido dele não prova que ela alcance juridicamente o interior de um carro particular. Pode ter sido precaução dele, política da plataforma ou simples experiência de quem roda pela ilha todo dia. Seja qual for o motivo, o efeito prático é o mesmo: <strong>leve uma camiseta na mochila de praia</strong>, porque você pode precisar dela antes mesmo de pisar na calçada.</p>
 </div>
 
 <div class="callout callout-tip">


### PR DESCRIPTION
## 📑 Description
Add "Gasto por dia" and "Gasto por categoria" charts plus full cost tables, and expand several day-by-day sections with more detail (Golden Bay, Blue Grotto, Comino, drinking and driving law, Paceville nightlife). Update description, tags and reading_time to reflect the added content.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Expand the Malta travel post with a more detailed itinerary, practical guidance, and comprehensive cost analysis.

New Features:
- Add daily and category-based cost charts plus expanded travel cost tables to the Malta itinerary post.
- Expand the guide with additional destination, nightlife, accommodation, travel-law, and practical planning details, including Crystal Lagoon and Malta’s drinking-and-driving guidance.

Bug Fixes:
- Correct and clarify itinerary timings, expenses, destination descriptions, and travel details throughout the Malta post.

Enhancements:
- Reorganize and substantially enrich the day-by-day Malta travel narrative with updated recommendations, comparisons, provider information, references, and a prior-trip section.

Documentation:
- Update the Malta post description, tags, reading time, cost breakdowns, travel advice, and supporting references.

Chores:
- Add the crystal-lagoon tag to the site tag data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the “Crystal Lagoon” tag for improved content categorization and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->