### PR TITLE
update: expand article with seniority bifurcation

### DIFF
--- a/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
+++ b/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
@@ -7,7 +7,7 @@ categories: [Career]
 subcategories:
   - "Career/Seniority"
 tags: [senioridade, entrevista-tecnica, carreira-dev, contratacao, junior-pleno-senior, mercado-de-trabalho]
-reading_time: 18
+reading_time: 23
 cover: /assets/img/posts/junior-pleno-senior-entrevista.svg
 image: /assets/img/posts/junior-pleno-senior-entrevista.png
 medium_tags: [carreira, programacao, entrevista, senioridade, tecnologia]
@@ -413,6 +413,110 @@ Como diferenciar uma promoção real de uma promoção de retenção? Pelo que *
 
 <div class="section-header">
   <div class="section-num">10</div>
+  <div class="section-title-wrap"><h2>Depois do sênior, a estrada se divide</h2></div>
+</div>
+
+Até aqui eu tratei a carreira como uma escada única. Ela não é. Júnior, pleno e sênior formam um tronco comum, mas no topo desse tronco existe uma bifurcação — e muita gente descobre isso tarde demais, já tendo aceitado virar gestor por falta de alternativa visível.
+
+<img
+  src="{{ site.baseurl }}/assets/img/posts/senioridade-trilhas-ic-gestao.svg"
+  alt="Fluxograma da carreira: tronco comum de estudante a sênior, depois bifurcação entre trilha de especialista (Staff, Principal, Distinguished) e trilha de gestão (EM, Senior EM, Director, VP e C-level)"
+  style="width:100%;max-width:860px;display:block;margin:1.75rem auto;border-radius:8px;border:1px solid var(--border);box-shadow:0 4px 20px rgba(26,23,20,.08);">
+
+Três leituras importam nesse desenho:
+
+<div class="providers-grid">
+  <div class="provider-card">
+    <div class="provider-name">A troca é lateral</div>
+    <div class="provider-detail">Em escadas bem desenhadas, Staff e Engineering Manager ficam na <strong>mesma faixa salarial</strong>. Virar gestor não é subir — é mudar de ofício. Se na sua empresa gestão é o único jeito de ganhar mais, a escada está mal feita.</div>
+  </div>
+  <div class="provider-card">
+    <div class="provider-name">Dá para voltar</div>
+    <div class="provider-detail">Trajetórias como Staff → EM → Senior Staff são comuns e saudáveis. Gestão não é porta de sentido único, embora muita gente a trate assim.</div>
+  </div>
+  <div class="provider-card">
+    <div class="provider-name">A entrada direta existe</div>
+    <div class="provider-detail">No Brasil é bem comum alguém entrar direto em gestão sem nunca ter sido IC. Funciona, mas cria um gestor que não consegue calibrar estimativa nem avaliar risco técnico — exatamente o que este artigo inteiro mede.</div>
+  </div>
+</div>
+
+<h3>Trilha IC — o especialista</h3>
+
+<table class="compare-table">
+  <thead>
+    <tr>
+      <th>Nome comum no BR</th>
+      <th>Nível</th>
+      <th>Título usual em inglês</th>
+      <th>Google</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Estudante</td><td>—</td><td><em>não é cargo</em></td><td>—</td></tr>
+    <tr><td>Estagiário</td><td>IC0</td><td>Intern</td><td>L2</td></tr>
+    <tr><td><strong>Júnior</strong></td><td>IC1</td><td>Software Engineer / SWE I</td><td>L3</td></tr>
+    <tr><td><strong>Pleno</strong></td><td>IC2</td><td>Software Engineer II / mid-level</td><td>L4</td></tr>
+    <tr><td><strong>Sênior</strong></td><td>IC3</td><td>Senior Software Engineer</td><td>L5</td></tr>
+    <tr><td>Especialista / Staff</td><td>IC4</td><td>Staff Engineer</td><td>L6</td></tr>
+    <tr><td>Principal</td><td>IC5</td><td>Senior Staff / Principal Engineer</td><td>L7–L8</td></tr>
+    <tr><td>—</td><td>IC6+</td><td>Distinguished Engineer, Fellow</td><td>L9–L10</td></tr>
+  </tbody>
+</table>
+
+<div class="callout callout-warn">
+  <div class="callout-label">Staff vem antes de Principal — não o contrário</div>
+  Essa é a confusão mais frequente. No Google a sequência é L5 sênior, L6 Staff, L7 Senior Staff e L8 Principal; na Meta, E5 sênior, E6 Staff e E7 Principal. A Amazon é a exceção que alimenta o engano: ela não tem degrau de Staff, então salta de Senior SDE (L6) direto para Principal (L7), o que faz o título parecer mais próximo do sênior do que realmente é. E <strong>"tech lead" não é nível nenhum</strong> — é um papel atribuído, quase sempre a um sênior, que muda de pessoa conforme o projeto.
+</div>
+
+<h3>Trilha de gestão</h3>
+
+<table class="compare-table">
+  <thead>
+    <tr>
+      <th>Nome comum no BR</th>
+      <th>Nível</th>
+      <th>Título usual em inglês</th>
+      <th>Escopo</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Coordenador / Tech Lead Manager</td><td>EM1</td><td>Engineering Manager</td><td>Um time</td></tr>
+    <tr><td>Gerente de Engenharia</td><td>EM2</td><td>Senior / Group EM</td><td>Gerentes e ICs sêniores</td></tr>
+    <tr><td>Diretor</td><td>EM3</td><td>Director of Engineering</td><td>Uma área inteira</td></tr>
+    <tr><td>VP / Diretoria executiva</td><td>EM4+</td><td>VP Eng, CTO, CIO, CISO, CDO</td><td>Empresa</td></tr>
+  </tbody>
+</table>
+
+<div class="callout callout-tip">
+  <div class="callout-label">Sobre a nomenclatura em si</div>
+  As colunas "IC" e "EM" existem aqui para dar uma régua neutra — elas são convenção de mercado, não padrão oficial. Cada empresa usa a sua: L no Google, E na Meta, SDE na Amazon, ICT na Apple, números soltos na Microsoft. Se você está traduzindo seu currículo, o que importa é a <strong>coluna de escopo</strong>, não a sigla.
+</div>
+
+<h3>"Júnior" é um termo brasileiro?</h3>
+
+Essa é uma observação que eu carrego há anos, e vale separar o que os dados sustentam do que não sustentam.
+
+<div class="providers-grid">
+  <div class="provider-card">
+    <div class="provider-name">✗ O que se refuta</div>
+    <div class="provider-detail">"Junior Software Developer" <strong>existe</strong> em vagas nos EUA e no Reino Unido. Aparece bastante em <em>defense contractors</em>, consultorias, agências de <em>staffing</em> e empresas menores. Não é um termo exclusivo do português.</div>
+  </div>
+  <div class="provider-card">
+    <div class="provider-name">✓ O que se confirma</div>
+    <div class="provider-detail">Nenhuma escada de big tech tem um degrau chamado "Junior". A entrada é numerada: L3 no Google, E3 na Meta, SDE I na Amazon, ICT2 na Apple. O título some justamente onde a trilha é formalizada.</div>
+  </div>
+  <div class="provider-card">
+    <div class="provider-name">→ O que é de fato nosso</div>
+    <div class="provider-detail"><strong>"Pleno."</strong> O inglês tem "mid-level", que é um adjetivo descritivo, não um cargo. A tríade fixa júnior/pleno/sênior como escala de três degraus é convenção lusófona — a Farfetch usar "júnior" reforça isso, já que é uma empresa portuguesa.</div>
+  </div>
+</div>
+
+Ou seja: sua percepção estava mais certa do que errada, só apontando para a palavra vizinha. O que não se traduz não é "júnior" — é **"pleno"**. E isso tem uma consequência prática desagradável: quem se descreve como "pleno" num currículo em inglês está usando um rótulo que o recrutador do outro lado não consegue mapear. O termo que ele espera ler é o título do nível, não a escala.
+
+<div class="divider">· · ·</div>
+
+<div class="section-header">
+  <div class="section-num">11</div>
   <div class="section-title-wrap"><h2>O que a gente realmente avalia</h2></div>
 </div>
 
@@ -475,7 +579,7 @@ Traduzindo cada linha em pergunta concreta que eu me faço:
 <div class="divider">· · ·</div>
 
 <div class="section-header">
-  <div class="section-num">11</div>
+  <div class="section-num">12</div>
   <div class="section-title-wrap"><h2>Como treinar isso de propósito</h2></div>
 </div>
 
@@ -533,6 +637,18 @@ Vivência acumula sozinha com o tempo, mas dá para acelerar bastante. Algumas c
     <li>
       Revelo. <strong>Desenvolvedor júnior, pleno e sênior: saiba qual contratar.</strong>
       <a href="https://blog.revelo.com.br/desenvolvedor-saiba-qual-nivel-contratar/" target="_blank">blog.revelo.com.br</a>
+    </li>
+    <li>
+      DesignGurus. <strong>Staff Engineer vs Principal Engineer: What Changes Beyond L6.</strong>
+      <a href="https://designgurus.substack.com/p/staff-engineer-vs-principal-engineer" target="_blank">designgurus.substack.com</a>
+    </li>
+    <li>
+      DesignGurus. <strong>FAANG Software Engineer Levels Explained: Apple ICT, Google L, Meta E, Amazon SDE.</strong>
+      <a href="https://www.designgurus.io/blog/understanding-faang-software-engineer-job-levels" target="_blank">designgurus.io</a>
+    </li>
+    <li>
+      sph.sh. <strong>Understanding Career Levels in Tech Companies.</strong>
+      <a href="https://sph.sh/en/posts/career-levels-tech-companies/" target="_blank">sph.sh</a>
     </li>
     <li>
       MDN Web Docs. <strong>Intl.DateTimeFormat.</strong>

--- a/assets/img/posts/junior-pleno-senior-entrevista.svg
+++ b/assets/img/posts/junior-pleno-senior-entrevista.svg
@@ -1,49 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Júnior, pleno ou sênior — a pergunta de entrevista que separa os três">
-  <rect width="1200" height="630" fill="#f5f0e8"/>
-  <rect x="32" y="32" width="1136" height="566" fill="none" stroke="#d9d0c2" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 400" width="1200" height="706" role="img" aria-label="Júnior, pleno ou sênior — a pergunta de entrevista que separa os três">
+  <rect width="680" height="400" fill="#f5f0e8"/>
+  <rect x="18" y="18" width="644" height="364" fill="none" stroke="#d9d0c2" stroke-width="1"/>
 
-  <text x="76" y="110" font-family="JetBrains Mono" font-size="20" letter-spacing="5" fill="#b85c00">CARREIRA · SENIORIDADE</text>
+  <text x="44" y="62" font-family="'JetBrains Mono', monospace" font-size="12" letter-spacing="3.2" fill="#b85c00">CARREIRA · SENIORIDADE</text>
 
-  <text x="76" y="212" font-family="Playfair Display" font-weight="600" font-size="76" fill="#1a1714">Júnior, pleno</text>
-  <text x="76" y="298" font-family="Playfair Display" font-weight="600" font-size="76" fill="#1a1714">ou sênior<tspan fill="#b85c00">?</tspan></text>
+  <text x="44" y="126" font-family="'Playfair Display', Georgia, serif" font-size="44" fill="#1a1714">Júnior, pleno</text>
+  <text x="44" y="176" font-family="'Playfair Display', Georgia, serif" font-size="44" fill="#1a1714">ou sênior<tspan fill="#b85c00">?</tspan></text>
 
-  <rect x="76" y="332" width="100" height="5" fill="#2d6a4f"/>
+  <rect x="44" y="200" width="58" height="3" fill="#2d6a4f"/>
 
-  <text x="76" y="390" font-family="Source Serif 4" font-size="30" fill="#5a534a">Uma demanda. Três respostas.</text>
-  <text x="76" y="432" font-family="Source Serif 4" font-size="30" fill="#5a534a">Nenhuma linha de código necessária.</text>
+  <text x="44" y="236" font-family="'Source Serif 4', Georgia, serif" font-size="18" fill="#5a534a">Uma demanda. Três respostas.</text>
+  <text x="44" y="260" font-family="'Source Serif 4', Georgia, serif" font-size="18" fill="#5a534a">Nenhuma linha de código necessária.</text>
 
-  <g font-family="JetBrains Mono" font-size="20" fill="#8a8078">
-    <rect x="76" y="474" width="22" height="22" fill="#8a8078"/>
-    <text x="110" y="492">JR — escreve</text>
-    <rect x="350" y="474" width="22" height="22" fill="#b85c00"/>
-    <text x="384" y="492">PL — pergunta</text>
-    <rect x="640" y="474" width="22" height="22" fill="#2d6a4f"/>
-    <text x="674" y="492">SR — antecipa</text>
+  <g font-family="'JetBrains Mono', monospace" font-size="11" fill="#8a8078">
+    <rect x="44" y="288" width="14" height="14" fill="#8a8078"/>
+    <text x="68" y="299">JR — escreve</text>
+
+    <rect x="200" y="288" width="14" height="14" fill="#b85c00"/>
+    <text x="224" y="299">PL — pergunta</text>
+
+    <rect x="366" y="288" width="14" height="14" fill="#2d6a4f"/>
+    <text x="390" y="299">SR — antecipa</text>
   </g>
 
-  <g>
-    <rect x="830" y="100" width="270" height="270" fill="none" stroke="#d9d0c2"/>
-    <rect x="860" y="130" width="42" height="42" fill="#8a8078"/>
-    <rect x="916" y="130" width="42" height="42" fill="#c9bfae"/>
-    <rect x="972" y="130" width="42" height="42" fill="#8a8078" opacity="0.45"/>
-    <rect x="1028" y="130" width="42" height="42" fill="#c9bfae" opacity="0.6"/>
-    <rect x="860" y="186" width="42" height="42" fill="#e0a35c"/>
-    <rect x="916" y="186" width="42" height="42" fill="#b85c00"/>
-    <rect x="972" y="186" width="42" height="42" fill="#e0a35c" opacity="0.6"/>
-    <rect x="1028" y="186" width="42" height="42" fill="#b85c00" opacity="0.45"/>
-    <rect x="860" y="242" width="42" height="42" fill="#2d6a4f" opacity="0.55"/>
-    <rect x="916" y="242" width="42" height="42" fill="#93c97a"/>
-    <rect x="972" y="242" width="42" height="42" fill="#2d6a4f"/>
-    <rect x="1028" y="242" width="42" height="42" fill="#93c97a" opacity="0.6"/>
-    <rect x="860" y="298" width="42" height="42" fill="#c9bfae" opacity="0.5"/>
-    <rect x="916" y="298" width="42" height="42" fill="#e0a35c" opacity="0.35"/>
-    <rect x="972" y="298" width="42" height="42" fill="#93c97a" opacity="0.4"/>
-    <rect x="1028" y="298" width="42" height="42" fill="none" stroke="#b85c00" stroke-dasharray="4 4"/>
+  <g opacity="0.9">
+    <rect x="470" y="60" width="152" height="152" fill="none" stroke="#d9d0c2"/>
+    <rect x="486" y="76" width="24" height="24" fill="#8a8078"/>
+    <rect x="518" y="76" width="24" height="24" fill="#c9bfae"/>
+    <rect x="550" y="76" width="24" height="24" fill="#8a8078" opacity="0.45"/>
+    <rect x="582" y="76" width="24" height="24" fill="#c9bfae" opacity="0.6"/>
+    <rect x="486" y="108" width="24" height="24" fill="#e0a35c"/>
+    <rect x="518" y="108" width="24" height="24" fill="#b85c00"/>
+    <rect x="550" y="108" width="24" height="24" fill="#e0a35c" opacity="0.6"/>
+    <rect x="582" y="108" width="24" height="24" fill="#b85c00" opacity="0.45"/>
+    <rect x="486" y="140" width="24" height="24" fill="#2d6a4f" opacity="0.55"/>
+    <rect x="518" y="140" width="24" height="24" fill="#93c97a"/>
+    <rect x="550" y="140" width="24" height="24" fill="#2d6a4f"/>
+    <rect x="582" y="140" width="24" height="24" fill="#93c97a" opacity="0.6"/>
+    <rect x="486" y="172" width="24" height="24" fill="#c9bfae" opacity="0.5"/>
+    <rect x="518" y="172" width="24" height="24" fill="#e0a35c" opacity="0.35"/>
+    <rect x="550" y="172" width="24" height="24" fill="#93c97a" opacity="0.4"/>
+    <rect x="582" y="172" width="24" height="24" fill="none" stroke="#b85c00" stroke-dasharray="3 3"/>
   </g>
-  <text x="830" y="404" font-family="JetBrains Mono" font-size="15" letter-spacing="1.8" fill="#8a8078">UM BOX 10×10, UMA COR POR DIA</text>
-  <text x="830" y="428" font-family="JetBrains Mono" font-size="15" letter-spacing="1.8" fill="#b85c00">…E O DIA 29/02?</text>
+  <text x="470" y="232" font-family="'JetBrains Mono', monospace" font-size="10" letter-spacing="1.6" fill="#8a8078">UM BOX 10×10, UMA COR POR DIA</text>
+  <text x="470" y="248" font-family="'JetBrains Mono', monospace" font-size="10" letter-spacing="1.6" fill="#b85c00">…E O DIA 29/02?</text>
 
-  <line x1="76" y1="548" x2="1124" y2="548" stroke="#d9d0c2"/>
-  <text x="76" y="584" font-family="JetBrains Mono" font-size="18" letter-spacing="2" fill="#8a8078">GUILHERME BRANCO STRACINI</text>
-  <text x="1124" y="584" text-anchor="end" font-family="JetBrains Mono" font-size="18" letter-spacing="2" fill="#8a8078">GUILHERME.STRACINI.COM.BR</text>
+  <line x1="44" y1="336" x2="636" y2="336" stroke="#d9d0c2"/>
+  <text x="44" y="360" font-family="'JetBrains Mono', monospace" font-size="11" letter-spacing="1.4" fill="#8a8078">GUILHERME BRANCO STRACINI</text>
+  <text x="636" y="360" text-anchor="end" font-family="'JetBrains Mono', monospace" font-size="11" letter-spacing="1.4" fill="#8a8078">GUILHERME.STRACINI.COM.BR</text>
 </svg>

--- a/assets/img/posts/senioridade-tempo-promocao.svg
+++ b/assets/img/posts/senioridade-tempo-promocao.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 420" width="680" height="420" role="img" aria-label="Gráfico comparando o tempo típico até a próxima promoção em big tech, no mercado brasileiro médio e em empresas que promovem para reter">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 420" width="680" height="420" role="img" aria-label="Linha do tempo de carreira mostrando com quantos anos de experiência acumulada cada título costuma chegar em big tech, no mercado brasileiro e em empresas que promovem para reter">
   <style>
     .gt{font-family:'Playfair Display',Georgia,serif;font-size:19px;fill:#1a1714}
     .gg{font-family:'JetBrains Mono',Consolas,monospace;font-size:12px;fill:#8a8078;letter-spacing:1.5px}
@@ -8,45 +8,47 @@
   </style>
   <rect width="680" height="420" fill="#f2ede6"/>
 
-  <text class="gt" x="20" y="34">Tempo típico até a próxima promoção</text>
-  <text class="gx" x="20" y="54">faixas usuais de mercado — anos no nível atual</text>
+  <text class="gt" x="20" y="34">Quando cada título costuma chegar</text>
+  <text class="gx" x="20" y="54">faixa de experiência acumulada em que a promoção normalmente acontece</text>
 
   <line x1="210" y1="70" x2="210" y2="330" stroke="#e2dbd0"/>
-  <line x1="322.5" y1="70" x2="322.5" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
-  <line x1="435" y1="70" x2="435" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
-  <line x1="547.5" y1="70" x2="547.5" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
-  <line x1="660" y1="70" x2="660" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="292" y1="70" x2="292" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="374" y1="70" x2="374" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="456" y1="70" x2="456" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="538" y1="70" x2="538" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="620" y1="70" x2="620" y2="330" stroke="#e2dbd0" stroke-dasharray="3 4"/>
 
   <text class="gg" x="20" y="92">BIG TECH / MULTINACIONAL</text>
-  <rect x="294.4" y="102" width="84.4" height="20" rx="3" fill="#2d6a4f"/>
-  <text class="gl" x="20" y="117">Júnior → Pleno</text>
-  <text class="gv" x="386" y="117">1,5–3 anos</text>
-  <rect x="378.8" y="132" width="168.8" height="20" rx="3" fill="#2d6a4f" opacity="0.75"/>
-  <text class="gl" x="20" y="147">Pleno → Sênior</text>
-  <text class="gv" x="555" y="147">3–6 anos</text>
+  <rect x="271.5" y="102" width="61.5" height="20" rx="3" fill="#2d6a4f"/>
+  <text class="gl" x="20" y="117">Vira Pleno</text>
+  <text class="gv" x="341" y="117">1,5–3 anos de carreira</text>
+  <rect x="456" y="132" width="123" height="20" rx="3" fill="#2d6a4f" opacity="0.75"/>
+  <text class="gl" x="20" y="147">Vira Sênior</text>
+  <text class="gv" x="587" y="147">6–9</text>
 
   <text class="gg" x="20" y="184">MERCADO BR — MÉDIA</text>
-  <rect x="322.5" y="194" width="112.5" height="20" rx="3" fill="#b85c00"/>
-  <text class="gl" x="20" y="209">Júnior → Pleno</text>
-  <text class="gv" x="442" y="209">2–4 anos</text>
-  <rect x="378.8" y="224" width="112.5" height="20" rx="3" fill="#b85c00" opacity="0.75"/>
-  <text class="gl" x="20" y="239">Pleno → Sênior</text>
-  <text class="gv" x="499" y="239">3–5 anos</text>
+  <rect x="292" y="194" width="82" height="20" rx="3" fill="#b85c00"/>
+  <text class="gl" x="20" y="209">Vira Pleno</text>
+  <text class="gv" x="382" y="209">2–4 anos de carreira</text>
+  <rect x="415" y="224" width="123" height="20" rx="3" fill="#b85c00" opacity="0.75"/>
+  <text class="gl" x="20" y="239">Vira Sênior</text>
+  <text class="gv" x="546" y="239">5–8</text>
 
   <text class="gg" x="20" y="276">PROMOÇÃO DE RETENÇÃO</text>
-  <rect x="238.1" y="286" width="28.1" height="20" rx="3" fill="#cc4444"/>
-  <text class="gl" x="20" y="301">Júnior → Pleno</text>
-  <text class="gv" x="274" y="301">6 meses–1 ano</text>
-  <rect x="266.2" y="316" width="56.2" height="20" rx="3" fill="#cc4444" opacity="0.75"/>
-  <text class="gl" x="20" y="331">Pleno → Sênior</text>
-  <text class="gv" x="330" y="331">1–2 anos</text>
+  <rect x="230.5" y="286" width="20.5" height="20" rx="3" fill="#cc4444"/>
+  <text class="gl" x="20" y="301">Vira Pleno</text>
+  <text class="gv" x="259" y="301">0,5–1 ano de carreira</text>
+  <rect x="271.5" y="316" width="61.5" height="20" rx="3" fill="#cc4444" opacity="0.75"/>
+  <text class="gl" x="20" y="331">Vira Sênior</text>
+  <text class="gv" x="341" y="331">1,5–3 — o mesmo ponto em que a big tech dá Pleno</text>
 
-  <line x1="210" y1="346" x2="660" y2="346" stroke="#8a8078"/>
+  <line x1="210" y1="346" x2="620" y2="346" stroke="#8a8078"/>
   <text class="gx" x="210" y="364" text-anchor="middle">0</text>
-  <text class="gx" x="322.5" y="364" text-anchor="middle">2</text>
-  <text class="gx" x="435" y="364" text-anchor="middle">4</text>
-  <text class="gx" x="547.5" y="364" text-anchor="middle">6</text>
-  <text class="gx" x="660" y="364" text-anchor="middle">8</text>
-  <text class="gx" x="435" y="384" text-anchor="middle">ANOS DE EXPERIÊNCIA ACUMULADA</text>
-  <text class="gx" x="20" y="408">Faixas indicativas. Empresas variam; o eixo mede experiência total, não tempo de casa.</text>
+  <text class="gx" x="292" y="364" text-anchor="middle">2</text>
+  <text class="gx" x="374" y="364" text-anchor="middle">4</text>
+  <text class="gx" x="456" y="364" text-anchor="middle">6</text>
+  <text class="gx" x="538" y="364" text-anchor="middle">8</text>
+  <text class="gx" x="620" y="364" text-anchor="middle">10</text>
+  <text class="gx" x="415" y="384" text-anchor="middle">ANOS DE EXPERIÊNCIA ACUMULADA NA CARREIRA</text>
+  <text class="gx" x="20" y="408">Faixas indicativas. Cada barra marca quando o título chega, não quanto tempo dura o nível.</text>
 </svg>

--- a/assets/img/posts/senioridade-trilhas-ic-gestao.svg
+++ b/assets/img/posts/senioridade-trilhas-ic-gestao.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 764" width="680" height="764" role="img" aria-label="Fluxograma da carreira em engenharia: tronco comum de estudante até sênior, seguido da bifurcação entre a trilha de especialista individual e a trilha de gestão">
+  <style>
+    .bx{font-family:'Source Serif 4',Georgia,serif;font-size:16px;fill:#1a1714}
+    .bxm{font-family:'Source Serif 4',Georgia,serif;font-size:16px;fill:#5a534a}
+    .hd{font-family:'JetBrains Mono',Consolas,monospace;font-size:14px;fill:#faf9f6;letter-spacing:1.5px}
+    .tag{font-family:'JetBrains Mono',Consolas,monospace;font-size:12px;fill:#8a8078}
+    .nt{font-family:'JetBrains Mono',Consolas,monospace;font-size:12px;fill:#8a8078}
+    .dz{font-family:'JetBrains Mono',Consolas,monospace;font-size:11px;fill:#b85c00;letter-spacing:1px}
+  </style>
+  <rect width="680" height="764" fill="#f2ede6"/>
+  <defs>
+    <marker id="ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 z" fill="#8a8078"/>
+    </marker>
+    <marker id="aro" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 z" fill="#b85c00"/>
+    </marker>
+  </defs>
+
+  <text class="tag" x="20" y="26" letter-spacing="2">TRONCO COMUM</text>
+
+  <rect x="150" y="40" width="340" height="44" rx="4" fill="#faf9f6" stroke="#c9bfae" stroke-dasharray="5 4"/>
+  <text class="bxm" x="172" y="68">Estudante — ainda não é um cargo</text>
+  <line x1="320" y1="84" x2="320" y2="100" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="150" y="100" width="340" height="44" rx="4" fill="#faf9f6" stroke="#c9bfae" stroke-dasharray="5 4"/>
+  <text class="bxm" x="172" y="128">Estágio / trainee — IC0 (opcional)</text>
+  <line x1="320" y1="144" x2="320" y2="160" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="150" y="160" width="340" height="44" rx="4" fill="#faf9f6" stroke="#2d6a4f"/>
+  <text class="bx" x="172" y="188">Júnior — IC1 · primeiro cargo de verdade</text>
+  <line x1="320" y1="204" x2="320" y2="220" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="150" y="220" width="340" height="44" rx="4" fill="#faf9f6" stroke="#2d6a4f"/>
+  <text class="bx" x="172" y="248">Pleno — IC2</text>
+  <line x1="320" y1="264" x2="320" y2="280" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="150" y="280" width="340" height="44" rx="4" fill="#e8f5ee" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text class="bx" x="172" y="308">Sênior — IC3 · aqui a estrada se divide</text>
+
+  <line x1="320" y1="324" x2="320" y2="348" stroke="#8a8078"/>
+  <line x1="175" y1="348" x2="505" y2="348" stroke="#8a8078"/>
+  <line x1="175" y1="348" x2="175" y2="372" stroke="#8a8078" marker-end="url(#ar)"/>
+  <line x1="505" y1="348" x2="505" y2="372" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="510" y="152" width="150" height="94" rx="4" fill="#fdf3e7" stroke="#b85c00" stroke-dasharray="5 4"/>
+  <text class="dz" x="524" y="176">ENTRADA DIRETA</text>
+  <text class="dz" x="524" y="194">EM GESTÃO, SEM</text>
+  <text class="dz" x="524" y="212">PASSAR PELO IC —</text>
+  <text class="dz" x="524" y="230">MAIS COMUM NO BR</text>
+  <line x1="585" y1="246" x2="585" y2="370" stroke="#b85c00" stroke-dasharray="5 4" marker-end="url(#aro)"/>
+
+  <rect x="20" y="374" width="310" height="34" rx="4" fill="#2d6a4f"/>
+  <text class="hd" x="38" y="396">TRILHA IC — ESPECIALISTA</text>
+  <rect x="350" y="374" width="310" height="34" rx="4" fill="#b85c00"/>
+  <text class="hd" x="368" y="396">TRILHA EM — GESTÃO</text>
+
+  <rect x="30" y="422" width="290" height="48" rx="4" fill="#faf9f6" stroke="#2d6a4f"/>
+  <text class="bx" x="50" y="444">Staff Engineer</text>
+  <text class="tag" x="50" y="462">IC4 · escopo além do time</text>
+  <line x1="175" y1="470" x2="175" y2="486" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="30" y="486" width="290" height="48" rx="4" fill="#faf9f6" stroke="#2d6a4f"/>
+  <text class="bx" x="50" y="508">Principal Engineer</text>
+  <text class="tag" x="50" y="526">IC5 · escopo de organização</text>
+  <line x1="175" y1="534" x2="175" y2="550" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="30" y="550" width="290" height="48" rx="4" fill="#faf9f6" stroke="#2d6a4f"/>
+  <text class="bx" x="50" y="572">Distinguished / Fellow</text>
+  <text class="tag" x="50" y="590">IC6+ · escopo de empresa</text>
+
+  <rect x="360" y="422" width="290" height="48" rx="4" fill="#faf9f6" stroke="#b85c00"/>
+  <text class="bx" x="380" y="444">Team Lead / Eng. Manager</text>
+  <text class="tag" x="380" y="462">EM1 · primeiro time</text>
+  <line x1="505" y1="470" x2="505" y2="486" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="360" y="486" width="290" height="48" rx="4" fill="#faf9f6" stroke="#b85c00"/>
+  <text class="bx" x="380" y="508">Senior / Group EM</text>
+  <text class="tag" x="380" y="526">EM2 · gerencia gerentes</text>
+  <line x1="505" y1="534" x2="505" y2="550" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="360" y="550" width="290" height="48" rx="4" fill="#faf9f6" stroke="#b85c00"/>
+  <text class="bx" x="380" y="572">Director of Engineering</text>
+  <text class="tag" x="380" y="590">EM3 · uma área inteira</text>
+  <line x1="505" y1="598" x2="505" y2="614" stroke="#8a8078" marker-end="url(#ar)"/>
+
+  <rect x="360" y="614" width="290" height="48" rx="4" fill="#faf9f6" stroke="#b85c00"/>
+  <text class="bx" x="380" y="636">VP · CTO · CIO · CISO</text>
+  <text class="tag" x="380" y="654">EM4+ · C-level</text>
+
+  <line x1="322" y1="446" x2="358" y2="446" stroke="#8a8078" stroke-dasharray="4 3"/>
+  <circle cx="340" cy="446" r="12" fill="#f2ede6" stroke="#8a8078" stroke-dasharray="3 3"/>
+  <text x="340" y="450" text-anchor="middle" font-family="'JetBrains Mono',monospace" font-size="12" fill="#5a534a">↔</text>
+
+  <line x1="20" y1="686" x2="660" y2="686" stroke="#e2dbd0"/>
+  <text class="nt" x="20" y="706">↔ Staff (IC4) e Engineering Manager (EM1) sentam na mesma faixa salarial.</text>
+  <text class="nt" x="20" y="726">A troca entre as trilhas é lateral — não é promoção, e dá para voltar.</text>
+  <text class="nt" x="20" y="746">No Brasil, "tech lead" costuma ser um papel dado a um sênior, não um degrau.</text>
+</svg>


### PR DESCRIPTION
## 📑 Description
Expand the existing article on distinguishing junior, mid-level, and senior developers to include detailed information about career paths beyond "senior." Introduce the concept of bifurcating into individual contributor (IC) vs. management tracks, which are often not clearly distinguished. Describe the progression in each track, clarifying common industry titles and roles at companies like Google and Amazon. Adjust the reading time from 18 to 23 minutes to reflect the added content. Update related images and infographics to align with new content, ensuring clarity on the career pathway division. Include additional references on tech career levels for further depth.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Expand the seniority article to explain career progression beyond senior through distinct specialist and management tracks.

New Features:
- Expand the career-seniority article with post-senior individual contributor and engineering management pathways, including common titles and company-level mappings.

Enhancements:
- Clarify that IC and management tracks can be equivalent, reversible career choices and distinguish formal levels from temporary roles such as tech lead.
- Add discussion of junior terminology across markets and explain how Brazilian career labels map to English titles.

Documentation:
- Increase the article reading-time estimate and add references covering Staff/Principal roles and technology-company career levels.

Chores:
- Update existing career illustrations and add an infographic showing the IC and management track bifurcation.