### PR TITLE
docs: update post on seniority to include new insights

### DIFF
--- a/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
+++ b/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
@@ -526,8 +526,10 @@ Em vez de inventar uma régua, vale olhar escadas reais: a da **Artsy** (aberta 
 
 <div class="callout callout-warn">
   <div class="callout-label">"IC5" não quer dizer nada sozinho</div>
-  Siga a linha do IC5 pelas colunas. Na Artsy, <strong>IC5 é Senior Engineer 2</strong> — sênior, ainda dentro do time. Na Talabat e no Yahoo, <strong>IC5 é Principal Engineer</strong> — dois degraus acima, com escopo de organização. A mesma sigla, em três empresas reais, descreve pessoas em estágios completamente diferentes de carreira. E o Dropbox comprime tudo em quatro níveis, onde <strong>L4 é um nível terminal</strong>: a documentação diz explicitamente que se espera que todo engenheiro chegue ao impacto de L4 <em>e possa ficar lá o resto da carreira</em>, sem pressão de subir.
+  Siga a linha do IC5 pelas colunas. Na Artsy, <strong>IC5 é Senior Engineer 2</strong> — sênior, ainda dentro do time. Na Talabat e no Yahoo, <strong>IC5 é Principal Engineer</strong> — dois degraus acima, com escopo de organização. A mesma sigla, em três empresas reais, descreve pessoas em estágios completamente diferentes de carreira.
 </div>
+
+O Dropbox ficou de fora dessa tabela justamente por não usar numeração IC — a escada dele é L1 a L4, e já apareceu na seção anterior. Vale citá-lo aqui por outro motivo: enquanto as quatro empresas acima esticam a escada até sete ou oito degraus, o Dropbox comprime tudo em quatro, e trata o <strong>L4 como nível terminal</strong>. A documentação diz que se espera que todo engenheiro alcance o impacto de L4 <em>e possa ficar lá o resto da carreira</em>, sem pressão de subir. Duas filosofias opostas sobre a mesma pergunta: escada longa com muitos degraus, ou escada curta em que a maioria chega ao topo e fica.
 
 A regra "Staff vem antes de Principal" vale no Google (L6 → L8), na Meta (E6 → E7), na Artsy (IC6 → IC8) e na Talabat (IC4 → IC5). Não vale no Yahoo nem na Amazon, que não têm degrau de Staff. E repare na coluna da Talabat: júnior IC1, pleno IC2, sênior IC3, Staff IC4, Principal IC5 — é a escada mais próxima da intuição brasileira que eu conheço, e existe de verdade. A régua "óbvia" não é errada; ela só não é universal.
 

--- a/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
+++ b/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
@@ -1,6 +1,5 @@
 ---
 layout: post
-lang: pt-BR
 title: "Júnior, pleno ou sênior: a pergunta de entrevista que separa os três"
 description: "Uma demanda fictícia de um PO, três candidatos e três respostas completamente diferentes. O que realmente avaliamos em uma entrevista técnica — e por que senioridade não é o tamanho da sua stack."
 date: 2026-08-30
@@ -8,7 +7,7 @@ categories: [Career]
 subcategories:
   - "Career/Seniority"
 tags: [senioridade, entrevista-tecnica, carreira-dev, contratacao, junior-pleno-senior, mercado-de-trabalho]
-reading_time: 27
+reading_time: 30
 cover: /assets/img/posts/junior-pleno-senior-entrevista.svg
 image: /assets/img/posts/junior-pleno-senior-entrevista.png
 medium_tags: [carreira, programacao, entrevista, senioridade, tecnologia]
@@ -96,6 +95,11 @@ Não há nada de burro nesse código. É a solução óbvia, direta, entregue r�
 - um dia tem sempre exatamente 86.400.000 milissegundos.
 
 Cada uma dessas cinco suposições é uma decisão de produto disfarçada de detalhe técnico. Ele tomou todas as cinco sozinho, em silêncio, e nenhuma delas foi validada com quem trouxe a demanda.
+
+<div class="callout callout-tip">
+  <div class="callout-label">E isso está previsto, formalmente</div>
+  Na matriz de competências da Talabat, o tema "Dealing with ambiguity" — lidar com ambiguidade — tem uma entrada explícita para o nível IC1: <strong>"n/a (not applicable at this level)"</strong>. Não é esquecimento nem indulgência. A empresa escreveu, com todas as letras, que não se espera que um júnior lide com ambiguidade. Ela aparece só a partir do IC2, e ainda assim limitada ao escopo pessoal de trabalho. Cobrar isso do candidato A seria avaliá-lo por um nível que ele não ocupa.
+</div>
 
 <div class="callout callout-warn">
   <div class="callout-label">O que isso me diz como avaliador</div>
@@ -289,6 +293,32 @@ O que é raro é **lembrar de perguntar**. E você não lembra porque leu — vo
   </div>
 </div>
 
+### A matriz que prova isso sozinha
+
+A matriz de competências da Talabat avalia **27 temas** distribuídos em cinco áreas: habilidades técnicas, entrega, feedback e comunicação, liderança e impacto estratégico. Cada tema tem uma descrição própria para cada um dos seis níveis, de IC1 a IC6.
+
+Com uma exceção. Exatamente **um** dos 27 temas para de evoluir depois do sênior. Nos três níveis acima — Staff, Principal, Senior Principal — a célula não traz um texto novo. Traz duas palavras: *"see IC3"*.
+
+<img
+  src="{{ site.baseurl }}/assets/img/posts/senioridade-horizonte-planejamento.svg"
+  alt="Horizonte de planejamento por nível: 1 a 5 dias no júnior, 1 a 4 semanas no pleno, 1 a 3 meses no sênior, 3 a 6 meses no Staff, 6 a 12 meses no Principal e 1 a 2 anos no Senior Principal"
+  style="width:100%;max-width:860px;display:block;margin:1.75rem auto;border-radius:8px;border:1px solid var(--border);box-shadow:0 4px 20px rgba(26,23,20,.08);">
+
+<div class="callout callout-warn">
+  <div class="callout-label">O tema que congela é "Writing code"</div>
+  Escrever código é a única competência das 27 que <strong>atinge o teto no sênior</strong>. A partir dali, a empresa formalmente não espera que você escreva código melhor — espera que você faça outras 26 coisas melhor. Um Principal Engineer e um sênior têm, no papel, exatamente a mesma expectativa de qualidade de código. Toda a distância entre os dois está em ambiguidade, arquitetura, alinhamento, mentoria, visão de produto e horizonte de decisão.
+</div>
+
+Isso é a tese deste artigo escrita por um departamento de RH, com carimbo. Se escrever código para de diferenciar no sênior, então tudo que vem depois — e boa parte do que vem antes — é outra coisa.
+
+E o gráfico acima mostra que outra coisa é essa. A matriz define, para cada nível, um **horizonte de planejamento**: por quanto tempo à frente aquela pessoa responde. Cinco dias no júnior. Um mês no pleno. Um trimestre no sênior. Dois anos no topo. Cada degrau multiplica o horizonte por mais ou menos quatro.
+
+<div class="callout callout-tip">
+  <div class="callout-label">Uma definição de senioridade em uma linha</div>
+  Se eu tivesse que resumir o artigo inteiro numa frase, seria essa: <strong>senioridade é o tamanho do futuro pelo qual você é responsável.</strong> O júnior responde pela tarefa desta semana. O sênior responde pelo que o time vai viver daqui a três meses. É exatamente por isso que o candidato C pergunta sobre ano bissexto: o bissexto está a quatro anos de distância, e o horizonte dele alcança lá.
+
+</div>
+
 É por isso que um dev que passou cinco anos numa única stack, mas mantendo um produto vivo com usuários reais, costuma ser mais sênior do que alguém que passou cinco anos pulando de projeto greenfield em greenfield. **Quem nunca manteve o próprio código não viu a consequência das próprias decisões** — e é exatamente esse feedback loop que constrói a intuição.
 
 <div class="personal-story">
@@ -470,35 +500,35 @@ Três leituras importam nesse desenho:
 
 <h3>Trilha IC — o especialista</h3>
 
-Em vez de inventar uma régua, vale olhar três escadas que estão publicadas na íntegra: a da **Artsy** (aberta no GitHub), a do **Dropbox** (publicada como site) e a do **Yahoo** (reconstruída por ex-funcionários em fóruns públicos). Elas discordam entre si de um jeito muito instrutivo:
+Em vez de inventar uma régua, vale olhar escadas reais: a da **Artsy** (aberta no GitHub), a do **Dropbox** (publicada como site), a do **Yahoo** (reconstruída por ex-funcionários em fóruns) e a da **Talabat**, que eu conheço de dentro — trabalhei lá entre 2021 e 2023, e a matriz de competências deles é o documento mais bem construído que já vi sobre isso. Elas discordam entre si de um jeito muito instrutivo:
 
 <table class="compare-table">
   <thead>
     <tr>
       <th>Nome no BR</th>
+      <th>Talabat</th>
       <th>Artsy</th>
       <th>Yahoo</th>
       <th>Google</th>
-      <th>Dropbox</th>
     </tr>
   </thead>
   <tbody>
-    <tr><td>Estagiário</td><td>Intern</td><td>—</td><td>L2</td><td>—</td></tr>
-    <tr><td><strong>Júnior</strong></td><td>Engineer 1 <em>(IC2)</em></td><td>Associate <em>(IC1)</em></td><td>L3</td><td>L1</td></tr>
-    <tr><td><strong>Pleno</strong></td><td>Engineer 2 <em>(IC3)</em></td><td>Software Engineer <em>(IC3)</em></td><td>L4</td><td>L2</td></tr>
-    <tr><td><strong>Sênior</strong></td><td>Senior Engineer 1–2 <em>(IC4–IC5)</em></td><td>Senior <em>(IC4)</em></td><td>L5</td><td>L3</td></tr>
-    <tr><td>Especialista</td><td>Staff <em>(IC6)</em></td><td>Principal <em>(IC5)</em></td><td>L6</td><td>L4</td></tr>
-    <tr><td>—</td><td>Senior Staff <em>(IC7)</em></td><td>Senior Principal <em>(IC6)</em></td><td>L7</td><td>—</td></tr>
-    <tr><td>—</td><td>Principal <em>(IC8)</em></td><td>Distinguished <em>(IC7–IC8)</em></td><td>L8</td><td>—</td></tr>
+    <tr><td>Estagiário</td><td>—</td><td>Intern</td><td>—</td><td>L2</td></tr>
+    <tr><td><strong>Júnior</strong></td><td>Engineer I <em>(IC1)</em></td><td>Engineer 1 <em>(IC2)</em></td><td>Associate <em>(IC1)</em></td><td>L3</td></tr>
+    <tr><td><strong>Pleno</strong></td><td>Engineer II <em>(IC2)</em></td><td>Engineer 2 <em>(IC3)</em></td><td>Software Engineer <em>(IC3)</em></td><td>L4</td></tr>
+    <tr><td><strong>Sênior</strong></td><td>Senior Engineer <em>(IC3)</em></td><td>Senior Engineer 1–2 <em>(IC4–IC5)</em></td><td>Senior <em>(IC4)</em></td><td>L5</td></tr>
+    <tr><td>Especialista</td><td>Staff <em>(IC4)</em></td><td>Staff <em>(IC6)</em></td><td>Principal <em>(IC5)</em></td><td>L6</td></tr>
+    <tr><td>—</td><td>Principal <em>(IC5)</em></td><td>Senior Staff <em>(IC7)</em></td><td>Senior Principal <em>(IC6)</em></td><td>L7</td></tr>
+    <tr><td>—</td><td>Sr. Principal <em>(IC6)</em></td><td>Principal <em>(IC8)</em></td><td>Distinguished <em>(IC7–IC8)</em></td><td>L8</td></tr>
   </tbody>
 </table>
 
 <div class="callout callout-warn">
   <div class="callout-label">"IC5" não quer dizer nada sozinho</div>
-  Compare as duas colunas do meio. Na Artsy, <strong>IC5 é Senior Engineer 2</strong> — sênior, ainda dentro do time. No Yahoo, <strong>IC5 é Principal Engineer</strong> — dois degraus acima, com escopo de organização. A mesma sigla, em duas empresas reais, descreve pessoas em estágios completamente diferentes de carreira. E o Dropbox comprime tudo em quatro níveis, onde <strong>L4 é um nível terminal</strong>: a documentação diz explicitamente que se espera que todo engenheiro chegue ao impacto de L4 <em>e possa ficar lá o resto da carreira</em>, sem pressão de subir.
+  Siga a linha do IC5 pelas colunas. Na Artsy, <strong>IC5 é Senior Engineer 2</strong> — sênior, ainda dentro do time. Na Talabat e no Yahoo, <strong>IC5 é Principal Engineer</strong> — dois degraus acima, com escopo de organização. A mesma sigla, em três empresas reais, descreve pessoas em estágios completamente diferentes de carreira. E o Dropbox comprime tudo em quatro níveis, onde <strong>L4 é um nível terminal</strong>: a documentação diz explicitamente que se espera que todo engenheiro chegue ao impacto de L4 <em>e possa ficar lá o resto da carreira</em>, sem pressão de subir.
 </div>
 
-Isso também nuança o que eu disse sobre Staff e Principal. A regra "Staff vem antes de Principal" vale no Google (L6 Staff → L8 Principal), na Meta (E6 → E7) e na Artsy (IC6 → IC8). Mas **não vale no Yahoo nem na Amazon**, onde não existe degrau de Staff e Principal aparece logo depois do sênior. Se você já viu "Principal" logo acima de sênior e achou estranho, não estava enganado — estava olhando uma escada dessas.
+A regra "Staff vem antes de Principal" vale no Google (L6 → L8), na Meta (E6 → E7), na Artsy (IC6 → IC8) e na Talabat (IC4 → IC5). Não vale no Yahoo nem na Amazon, que não têm degrau de Staff. E repare na coluna da Talabat: júnior IC1, pleno IC2, sênior IC3, Staff IC4, Principal IC5 — é a escada mais próxima da intuição brasileira que eu conheço, e existe de verdade. A régua "óbvia" não é errada; ela só não é universal.
 
 <h3>Trilha de gestão</h3>
 
@@ -554,6 +584,13 @@ Essa é uma observação que eu carrego há anos, e vale separar o que os dados 
 </div>
 
 Ou seja: sua percepção estava mais certa do que errada, só apontando para a palavra vizinha. O que não se traduz não é "júnior" — é **"pleno"**. E isso tem uma consequência prática desagradável: quem se descreve como "pleno" num currículo em inglês está usando um rótulo que o recrutador do outro lado não consegue mapear. O termo que ele espera ler é o título do nível, não a escala.
+
+<div class="personal-story">
+  <div class="personal-story-label">
+    <i class="fas fa-user-circle"></i> Minha experiência — a matriz que mudou minha cabeça
+  </div>
+  <p>Passei por vários processos de avaliação em que "nível" era uma conversa subjetiva entre o gestor e o RH. A primeira vez que vi isso escrito como documento sério foi na Talabat, em Dubai, entre 2021 e 2023. Não era uma lista de tecnologias — era uma grade de 27 competências, com o horizonte de planejamento e o escopo de impacto declarados em cada degrau. Foi lendo aquilo que eu entendi por que tinha passado tanto tempo achando que precisava aprender mais uma linguagem: eu estava tentando subir na única linha da tabela que para de contar no sênior.</p>
+</div>
 
 <div class="divider">· · ·</div>
 
@@ -716,6 +753,9 @@ Vivência acumula sozinha com o tempo, mas dá para acelerar bastante. Algumas c
     <li>
       sph.sh. <strong>Understanding Career Levels in Tech Companies.</strong>
       <a href="https://sph.sh/en/posts/career-levels-tech-companies/" target="_blank">sph.sh</a>
+    </li>
+    <li>
+      Talabat. <strong>Engineering Competency Matrix</strong> (documento interno, 2021–2023; inspirado na matriz pública da CircleCI). Consultado por experiência direta do autor.
     </li>
     <li>
       Dropbox. <strong>Engineering Career Framework — Promotion Guidelines &amp; Clarifications.</strong>

--- a/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
+++ b/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
@@ -294,7 +294,7 @@ O que é raro é **lembrar de perguntar**. E você não lembra porque leu — vo
   </div>
 </div>
 
-### A matriz que prova isso sozinha
+<h3>A matriz que prova isso sozinha</h3>
 
 A matriz de competências da Talabat avalia **27 temas** distribuídos em cinco áreas: habilidades técnicas, entrega, feedback e comunicação, liderança e impacto estratégico. Cada tema tem uma descrição própria para cada um dos seis níveis, de IC1 a IC6.
 
@@ -312,7 +312,7 @@ Com uma exceção. Exatamente **um** dos 27 temas para de evoluir depois do sên
 
 Isso é a tese deste artigo escrita por um departamento de RH, com carimbo. Se escrever código para de diferenciar no sênior, então tudo que vem depois — e boa parte do que vem antes — é outra coisa.
 
-E o gráfico acima mostra que outra coisa é essa. A matriz define, para cada nível, um **horizonte de planejamento**: por quanto tempo à frente aquela pessoa responde. Cinco dias no júnior. Um mês no pleno. Um trimestre no sênior. Dois anos no topo. Cada degrau multiplica o horizonte por mais ou menos quatro.
+E o gráfico acima mostra que outra coisa é essa. A matriz define, para cada nível, um **horizonte de planejamento**: por quanto tempo à frente aquela pessoa responde. Cinco dias no júnior. Um mês no pleno. Um trimestre no sênior. Dois anos no topo. O crescimento não é uniforme: o salto é brutal no começo — cerca de **5×** de júnior para pleno e **3×** de pleno para sênior — e depois se estabiliza em **2× a cada degrau**. Do IC1 ao IC6 o horizonte cresce quase 150 vezes.
 
 <div class="callout callout-tip">
   <div class="callout-label">Uma definição de senioridade em uma linha</div>
@@ -350,7 +350,7 @@ A resposta honesta é que depende brutalmente do tipo de empresa. O gráfico aba
   As faixas de big tech vêm de trilhas de nivelamento públicas — incluindo o framework de carreira do Dropbox, que publica os tempos por nível, e a escada da Artsy, aberta no GitHub. As do mercado brasileiro vêm de levantamentos de recrutamento referenciados. Já a linha de <strong>promoção de retenção</strong> e os percentuais de aumento citados adiante são <strong>estimativas ilustrativas</strong>, baseadas em padrão observado — não em pesquisa publicada. Trate-as como ordem de grandeza, não como dado.
 </div>
 
-### Um framework que publica os números
+<h3>Um framework que publica os números</h3>
 
 Quase toda empresa trata a matriz de promoção como documento interno. O Dropbox publicou a dele, e isso dá uma âncora rara — números oficiais, não crowdsourced:
 
@@ -377,7 +377,7 @@ Somando as faixas, uma pessoa entra no L3 com **3,5 a 5 anos** de carreira e no 
   A linha do gestor em L3 é mais curta que a do IC. O motivo está escrito na própria documentação: quem migra para gestão <strong>já cresceu através de boa parte do L3 como IC</strong>. O tempo não é menor porque gestão é mais fácil — é menor porque parte do caminho já foi andado do outro lado.
 </div>
 
-### O padrão das grandes empresas
+<h3>O padrão das grandes empresas</h3>
 
 Em empresas grandes, com trilha de carreira formalizada e comitê de calibração, os números são razoavelmente estáveis. No Google, o nível de entrada (L3) costuma durar entre um ano e meio e dois anos — ficar muito além disso é lido internamente como sinal de baixa performance. O L4, o degrau seguinte, corresponde grosso modo a algo entre um e cinco anos de mercado, e o título de Senior Software Engineer (L5) normalmente é associado a uma faixa de seis a nove anos de experiência. Meta, Amazon e Microsoft operam com trilhas diferentes no nome, mas com ordens de grandeza muito parecidas.
 
@@ -412,7 +412,7 @@ Traduzindo para a nomenclatura brasileira:
 
 Repare que a coluna que importa não é a do meio. É a da direita. Os anos são **proxy** da autonomia, não a causa dela.
 
-### O padrão das empresas pequenas — e a armadilha
+<h3>O padrão das empresas pequenas — e a armadilha</h3>
 
 Agora a parte que ninguém coloca no material institucional.
 
@@ -501,7 +501,7 @@ Três leituras importam nesse desenho:
 
 <h3>Trilha IC — o especialista</h3>
 
-Em vez de inventar uma régua, vale olhar escadas reais: a da **Artsy** (aberta no GitHub), a do **Dropbox** (publicada como site), a do **Yahoo** (reconstruída por ex-funcionários em fóruns) e a da **Talabat**, que eu conheço de dentro — trabalhei lá entre 2021 e 2023, e a matriz de competências deles é o documento mais bem construído que já vi sobre isso. Elas discordam entre si de um jeito muito instrutivo:
+Em vez de inventar uma régua, vale olhar escadas reais: a da **Artsy** (aberta no GitHub), a do **Yahoo** (reconstruída por ex-funcionários em fóruns), a do **Google** (mapeada publicamente por ex-recrutadores) e a da **Talabat**, que eu conheço de dentro — trabalhei lá entre 2021 e 2023, e a matriz de competências deles é o documento mais bem construído que já vi sobre isso. Elas discordam entre si de um jeito muito instrutivo:
 
 <table class="compare-table">
   <thead>

--- a/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
+++ b/_posts/2026-08-30-junior-pleno-senior-diferencas-praticas-entrevista.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+lang: pt-BR
 title: "Júnior, pleno ou sênior: a pergunta de entrevista que separa os três"
 description: "Uma demanda fictícia de um PO, três candidatos e três respostas completamente diferentes. O que realmente avaliamos em uma entrevista técnica — e por que senioridade não é o tamanho da sua stack."
 date: 2026-08-30

--- a/assets/img/posts/senioridade-horizonte-planejamento.svg
+++ b/assets/img/posts/senioridade-horizonte-planejamento.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 470" width="680" height="470" role="img" aria-label="Horizonte de planejamento por nível de senioridade: de 1 a 5 dias no júnior até 1 a 2 anos no senior principal, com o escopo correspondente">
+  <style>
+    .tt{font-family:'Playfair Display',Georgia,serif;font-size:19px;fill:#1a1714}
+    .sb{font-family:'JetBrains Mono',Consolas,monospace;font-size:11px;fill:#8a8078}
+    .lv{font-family:'Source Serif 4',Georgia,serif;font-size:16px;fill:#1a1714}
+    .sc{font-family:'JetBrains Mono',Consolas,monospace;font-size:11px;fill:#8a8078}
+    .in{font-family:'JetBrains Mono',Consolas,monospace;font-size:12px;fill:#faf9f6}
+    .ax{font-family:'JetBrains Mono',Consolas,monospace;font-size:10px;fill:#8a8078}
+  </style>
+  <rect width="680" height="470" fill="#f2ede6"/>
+
+  <text class="tt" x="20" y="32">O relógio da senioridade</text>
+  <text class="sb" x="20" y="52">horizonte de tempo pelo qual a pessoa responde — escala logarítmica</text>
+
+  <line x1="200" y1="70" x2="200" y2="382" stroke="#e2dbd0"/>
+  <line x1="332.8" y1="70" x2="332.8" y2="382" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="432.1" y1="70" x2="432.1" y2="382" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="507.1" y1="70" x2="507.1" y2="382" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+  <line x1="602.7" y1="70" x2="602.7" y2="382" stroke="#e2dbd0" stroke-dasharray="3 4"/>
+
+  <text class="lv" x="20" y="98">IC1 · Júnior</text>
+  <text class="sc" x="20" y="114">dentro da tarefa</text>
+  <rect x="200" y="82" width="109.9" height="30" rx="3" fill="#8a8078"/>
+  <text class="in" x="300" y="102" text-anchor="end">1–5 dias</text>
+
+  <text class="lv" x="20" y="148">IC2 · Pleno</text>
+  <text class="sc" x="20" y="164">dentro do épico</text>
+  <rect x="200" y="132" width="227.4" height="30" rx="3" fill="#b85c00" opacity="0.75"/>
+  <text class="in" x="418" y="152" text-anchor="end">1–4 semanas</text>
+
+  <text class="lv" x="20" y="198">IC3 · Sênior</text>
+  <text class="sc" x="20" y="214">dentro do time</text>
+  <rect x="200" y="182" width="307.1" height="30" rx="3" fill="#b85c00"/>
+  <text class="in" x="498" y="202" text-anchor="end">1–3 meses</text>
+
+  <text class="lv" x="20" y="248">IC4 · Staff</text>
+  <text class="sc" x="20" y="264">time + outros times</text>
+  <rect x="200" y="232" width="354.4" height="30" rx="3" fill="#2d6a4f" opacity="0.7"/>
+  <text class="in" x="545" y="252" text-anchor="end">3–6 meses</text>
+
+  <text class="lv" x="20" y="298">IC5 · Principal</text>
+  <text class="sc" x="20" y="314">4+ times</text>
+  <rect x="200" y="282" width="402.7" height="30" rx="3" fill="#2d6a4f" opacity="0.85"/>
+  <text class="in" x="593" y="302" text-anchor="end">6–12 meses</text>
+
+  <text class="lv" x="20" y="348">IC6 · Sr. Principal</text>
+  <text class="sc" x="20" y="364">toda a organização</text>
+  <rect x="200" y="332" width="450" height="30" rx="3" fill="#2d6a4f"/>
+  <text class="in" x="640" y="352" text-anchor="end">1–2 anos</text>
+
+  <line x1="200" y1="382" x2="650" y2="382" stroke="#8a8078"/>
+  <text class="ax" x="200" y="398" text-anchor="middle">1 dia</text>
+  <text class="ax" x="332.8" y="398" text-anchor="middle">1 semana</text>
+  <text class="ax" x="432.1" y="398" text-anchor="middle">1 mês</text>
+  <text class="ax" x="507.1" y="398" text-anchor="middle">1 trimestre</text>
+  <text class="ax" x="602.7" y="398" text-anchor="middle">1 ano</text>
+
+  <line x1="20" y1="420" x2="660" y2="420" stroke="#e2dbd0"/>
+  <text class="sb" x="20" y="440">Cada degrau multiplica o horizonte por ~4. Do júnior ao Sr. Principal são</text>
+  <text class="sb" x="20" y="458">dois dias de trabalho contra dois anos — a mesma pessoa, outra unidade de tempo.</text>
+</svg>

--- a/search.html
+++ b/search.html
@@ -346,9 +346,8 @@ permalink: /busca/
       sortBar.style.display = '';
 
       const resultWord = docs.length !== 1 ? t('search_result_plural') : t('search_result_singular');
-      const forWord    = t('search_results_for');
-      const safeQuery  = escapeHtml(query);
-      const header = `<p class="results-header"><strong>${docs.length}</strong> ${resultWord} ${forWord} "<strong>${safeQuery}</strong>"</p>`;
+      const forPart    = query.trim() ? ` ${t('search_results_for')} "<strong>${escapeHtml(query)}</strong>"` : '';
+      const header = `<p class="results-header"><strong>${docs.length}</strong> ${resultWord}${forPart}</p>`;
       const cards  = docs.map((doc, i) => {
         const excerpt = truncateAround(doc.content, query);
         const cats    = doc.categories ? doc.categories.split(', ').filter(Boolean) : [];
@@ -388,8 +387,6 @@ permalink: /busca/
     function runSearch(query) {
       activeQuery = query;
       if (!query.trim()) {
-        showState('initial');
-        sortBar.style.display = 'none';
         clearBtn.classList.remove('visible');
         heroTitle.textContent = t('search_title');
         heroDesc.textContent  = t('search_desc');
@@ -398,6 +395,10 @@ permalink: /busca/
         const clearedUrl = new URL(window.location);
         clearedUrl.searchParams.delete('q');
         window.history.replaceState({}, '', clearedUrl);
+
+        // No active search: show every post, with sorting still available.
+        if (!indexReady) { showState('loading'); sortBar.style.display = 'none'; return; }
+        renderResults('', applySort(documents));
         return;
       }
       clearBtn.classList.add('visible');


### PR DESCRIPTION
## 📑 Description
Update the blog post "Júnior, pleno ou sênior" with additional insights on understanding seniority. Additions include a discussion of Talabat's competency matrix and its particular focus on "Dealing with ambiguity" not being expected at junior levels, with comparisons across industry standards. Include a new section on the planning horizon at different levels of seniority, emphasizing that seniority is not merely about accumulating technical skills but about handling increasingly complex responsibilities over longer time frames. This detail is supported by the new SVG image illustrating planning horizons across role levels.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Broaden the seniority article with competency-framework and planning-horizon insights while improving empty-query search behavior.

New Features:
- Expand the seniority article with Talabat competency-matrix insights and a planning-horizon model across career levels.
- Add a visual SVG illustrating planning horizons from junior through senior principal roles.

Bug Fixes:
- Keep search results visible and sortable when the search query is cleared.
- Avoid displaying an empty “results for” clause when no search term is active.

Enhancements:
- Update the article’s career-level comparison table and supporting discussion with Talabat, Google, Yahoo, Artsy, and Dropbox perspectives.
- Include the author’s direct experience with Talabat’s competency framework and add it to the article references.
- Adjust the article’s estimated reading time and normalize section heading markup.

Documentation:
- Revise the Portuguese seniority article to emphasize ambiguity handling, planning horizons, and responsibility for increasingly distant outcomes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the article with insights from Talabat’s engineering competency matrix.
  * Added guidance on ambiguity handling, planning horizons, and competency progression.
  * Updated career ladder comparisons and references, including Talabat.
  * Added a personal experience section and increased estimated reading time to 30 minutes.

* **Bug Fixes**
  * Improved search results for blank queries.
  * Removed the unnecessary empty-query label from results headers.
  * Kept sorting available while displaying all posts or loading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->