### PR TITLE
feat: add travel post map feature with filtering

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -140,6 +140,11 @@ pt-BR:
   table_article: "Artigo"
   table_date: "Data"
   travels_country_unknown: "Não especificado"
+  filter_year: "Ano"
+  filter_all_countries: "Todos os países"
+  filter_all_years: "Todos os anos"
+  travels_no_results: "Nenhum post para este filtro."
+  post_map_title: "No mapa"
 
 en:
   home: "Home"
@@ -283,3 +288,8 @@ en:
   table_article: "Article"
   table_date: "Date"
   travels_country_unknown: "Unspecified"
+  filter_year: "Year"
+  filter_all_countries: "All countries"
+  filter_all_years: "All years"
+  travels_no_results: "No posts match this filter."
+  post_map_title: "On the map"

--- a/_includes/post-map.html
+++ b/_includes/post-map.html
@@ -4,11 +4,10 @@
   fetched lazily by assets/js/post-map.js once the card scrolls into view.
 {% endcomment %}
 {% if page.location or page.locations %}
-{% if page.locations %}
-  {% assign _map_locs = page.locations %}
-{% else %}
-  {% assign _map_locs = "" | split: "" | push: page.location %}
-{% endif %}
+{% comment %} Same merge as the /viagens/ model: `locations` first, then `location`. {% endcomment %}
+{% assign _map_locs = "" | split: "" %}
+{% if page.locations %}{% assign _map_locs = _map_locs | concat: page.locations %}{% endif %}
+{% if page.location %}{% assign _map_locs = _map_locs | push: page.location %}{% endif %}
 <div class="article-card article-card--map">
   <p class="card-section-title">
     <i class="fas fa-map-location-dot"></i> &nbsp;<span data-i18n="post_map_title">{{ _t.post_map_title }}</span>

--- a/_includes/post-map.html
+++ b/_includes/post-map.html
@@ -1,0 +1,30 @@
+{% comment %}
+  Mini map for travel posts — rendered only when the post declares
+  `location` (object) or `locations` (array) in its front matter. Leaflet is
+  fetched lazily by assets/js/post-map.js once the card scrolls into view.
+{% endcomment %}
+{% if page.location or page.locations %}
+{% if page.locations %}
+  {% assign _map_locs = page.locations %}
+{% else %}
+  {% assign _map_locs = "" | split: "" | push: page.location %}
+{% endif %}
+<div class="article-card article-card--map">
+  <p class="card-section-title">
+    <i class="fas fa-map-location-dot"></i> &nbsp;<span data-i18n="post_map_title">{{ _t.post_map_title }}</span>
+  </p>
+  <div class="post-map" id="post-map"
+       data-locations="{{ _map_locs | jsonify | escape }}"
+       aria-label="{{ _t.post_map_title }}" data-i18n-aria="post_map_title"></div>
+  <ol class="post-map-list">
+    {% for loc in _map_locs %}
+    <li>
+      <button type="button" class="post-map-list-btn" data-index="{{ forloop.index0 }}">
+        <span class="post-map-list-num">{{ forloop.index }}</span>{{ loc.label }}
+      </button>
+    </li>
+    {% endfor %}
+  </ol>
+</div>
+<script src="{{ '/assets/js/post-map.js' | relative_url }}" defer></script>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -112,6 +112,9 @@
         <script src="{{ '/assets/js/table-scroll.js' | relative_url }}" defer></script>
       </div>
 
+      <!-- Card: mapa do post (só quando há location/locations no front matter) -->
+      {% include post-map.html %}
+
       <!-- Series pager: jump to previous / next part -->
       {% include series-pager.html %}
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -314,6 +314,17 @@ a { color: inherit; text-decoration: none; }
   font-family: 'JetBrains Mono', monospace; font-size: 0.72rem;
   color: var(--ink-light); text-align: center; padding: 1.5rem;
 }
+/* Shown over the map when the active filter has no mapped locations */
+.travel-map-card { position: relative; }
+.travel-map-empty {
+  position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  z-index: 500; /* above Leaflet's tile/marker panes (≤400), below its controls (1000) */
+  margin: 0; padding: .7rem 1.1rem; border-radius: 8px;
+  background: var(--card-bg); color: var(--ink-muted); border: 1px solid var(--border);
+  font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; letter-spacing: .04em;
+  box-shadow: 0 2px 12px rgba(0,0,0,.15); pointer-events: none;
+}
+.travel-map-empty[hidden] { display: none; }
 
 /* Post mini map — _includes/post-map.html + assets/js/post-map.js */
 .post-map {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -292,6 +292,61 @@ a { color: inherit; text-decoration: none; }
 #map { height: 65vh; min-height: 420px; width: 100%; display: block; }
 @media (max-width: 600px) { #map { height: 55vh; min-height: 320px; } }
 
+/* OSM tiles are light-only; flip them under the dark theme (both maps) */
+[data-theme="dark"] .leaflet-tile-pane { filter: invert(1) hue-rotate(180deg) brightness(.85) contrast(.9); }
+
+/* Filters — /viagens/ (travels.html + assets/js/travels-filter.js) */
+.travel-filters-card { padding: 1.25rem 1.5rem; }
+.travel-filters { display: flex; flex-wrap: wrap; gap: .9rem 1.75rem; align-items: flex-end; }
+.travel-filter { display: flex; flex-direction: column; gap: .35rem; min-width: 180px; }
+.travel-filter label {
+  font-family: 'JetBrains Mono', monospace; font-size: 0.59rem;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--ink-light);
+}
+.travel-filter select {
+  font-family: 'JetBrains Mono', monospace; font-size: 0.75rem;
+  padding: .45rem .7rem; border-radius: 8px;
+  border: 1px solid var(--border); background: var(--card-bg); color: var(--ink);
+  cursor: pointer;
+}
+.travel-filter select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.travels-table-empty {
+  font-family: 'JetBrains Mono', monospace; font-size: 0.72rem;
+  color: var(--ink-light); text-align: center; padding: 1.5rem;
+}
+
+/* Post mini map — _includes/post-map.html + assets/js/post-map.js */
+.post-map {
+  height: 340px; width: 100%;
+  border-radius: 10px; overflow: hidden;
+  border: 1px solid var(--border); background: var(--surface-warm);
+}
+@media (max-width: 600px) { .post-map { height: 260px; } }
+.leaflet-marker-icon.post-map-marker {
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%;
+  background: var(--accent); color: var(--chrome-light);
+  border: 2px solid var(--chrome-light);
+  box-shadow: 0 2px 6px rgba(0,0,0,.35);
+  font-family: 'JetBrains Mono', monospace; font-size: .72rem; font-weight: 500;
+}
+.leaflet-marker-icon.post-map-marker:focus-visible { outline: 2px solid var(--accent-warm); outline-offset: 2px; }
+.post-map-list { list-style: none; display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1rem; }
+.post-map-list-btn {
+  display: inline-flex; align-items: center; gap: .5rem;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.69rem; letter-spacing: .04em;
+  padding: 4px 12px 4px 4px; border-radius: 20px; cursor: pointer;
+  background: var(--tag-bg); border: 1px solid var(--border); color: var(--ink-muted);
+  transition: border-color .2s, color .2s;
+}
+.post-map-list-btn:hover,
+.post-map-list-btn:focus-visible { border-color: var(--accent); color: var(--ink); }
+.post-map-list-num {
+  width: 20px; height: 20px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--accent); color: var(--chrome-light); font-size: .62rem;
+}
+
 /* ─────────────────────────────────────
    PHOTO GALLERY (lightbox)
 ───────────────────────────────────── */

--- a/assets/js/post-map.js
+++ b/assets/js/post-map.js
@@ -63,13 +63,14 @@
       });
       var popup = document.createElement('div');
       popup.textContent = loc.label;
-      var marker = L.marker([loc.lat, loc.lng], { icon: icon, title: loc.label, keyboard: true })
-        .addTo(map)
-        .bindPopup(popup);
+      var marker = L.marker([loc.lat, loc.lng], { icon: icon, title: loc.label, keyboard: true });
       // divIcon has no `alt`; Leaflet already gives it role="button" + tabindex.
-      var iconEl = marker.getElement();
-      if (iconEl) iconEl.setAttribute('aria-label', (i + 1) + '. ' + loc.label);
-      return marker;
+      // The icon element only exists once the map has a view, so label on 'add'.
+      marker.on('add', function () {
+        var iconEl = marker.getElement();
+        if (iconEl) iconEl.setAttribute('aria-label', (i + 1) + '. ' + loc.label);
+      });
+      return marker.addTo(map).bindPopup(popup);
     });
 
     if (markers.length === 1) {

--- a/assets/js/post-map.js
+++ b/assets/js/post-map.js
@@ -1,0 +1,101 @@
+/* Mini map on travel posts (see _includes/post-map.html). Leaflet is only
+   fetched once the map card is about to scroll into view, so pages without
+   a map — and maps nobody scrolls to — pay nothing. */
+(function () {
+  'use strict';
+
+  var el = document.getElementById('post-map');
+  if (!el) return;
+
+  var locations;
+  try { locations = JSON.parse(el.dataset.locations || '[]'); } catch (e) { return; }
+  locations = locations.filter(function (l) { return Number.isFinite(l.lat) && Number.isFinite(l.lng); });
+  if (!locations.length) return;
+
+  var LEAFLET = {
+    css: { href: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css',
+           integrity: 'sha512-h9FcoyWjHcOcmEVkxOfTLnmZFWIH0iZhZT1H2TbOq55xssQGEJHEaIm+PgoUaZbRvQTNTluNOEfb1ZRy6D3BOw==' },
+    js:  { src: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js',
+           integrity: 'sha512-puJW3E/qXDqYp9IfhAI54BJEaWIfloJ7JWs7OeD5i6ruC9JZL1gERT1wjtwXFlh7CjE7ZJ+/vcRZRkIYIb6p4g==' }
+  };
+
+  function loadLeaflet(done) {
+    if (window.L) return done();
+    var pending = 2;
+    var settle = function () { if (--pending === 0) done(); };
+
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = LEAFLET.css.href;
+    link.integrity = LEAFLET.css.integrity;
+    link.crossOrigin = 'anonymous';
+    link.referrerPolicy = 'no-referrer';
+    link.onload = settle;
+    link.onerror = settle;
+    document.head.appendChild(link);
+
+    var script = document.createElement('script');
+    script.src = LEAFLET.js.src;
+    script.integrity = LEAFLET.js.integrity;
+    script.crossOrigin = 'anonymous';
+    script.referrerPolicy = 'no-referrer';
+    script.onload = settle;
+    document.head.appendChild(script);
+  }
+
+  function init() {
+    if (!window.L) return;
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var map = L.map(el, {
+      scrollWheelZoom: false,
+      zoomAnimation: !reducedMotion, fadeAnimation: !reducedMotion, markerZoomAnimation: !reducedMotion
+    });
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 18,
+      attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
+    }).addTo(map);
+
+    var markers = locations.map(function (loc, i) {
+      var icon = L.divIcon({
+        className: 'post-map-marker',
+        html: '<span>' + (i + 1) + '</span>',
+        iconSize: [28, 28], iconAnchor: [14, 14], popupAnchor: [0, -16]
+      });
+      var popup = document.createElement('div');
+      popup.textContent = loc.label;
+      var marker = L.marker([loc.lat, loc.lng], { icon: icon, title: loc.label, keyboard: true })
+        .addTo(map)
+        .bindPopup(popup);
+      // divIcon has no `alt`; Leaflet already gives it role="button" + tabindex.
+      var iconEl = marker.getElement();
+      if (iconEl) iconEl.setAttribute('aria-label', (i + 1) + '. ' + loc.label);
+      return marker;
+    });
+
+    if (markers.length === 1) {
+      map.setView(markers[0].getLatLng(), 10);
+    } else {
+      map.fitBounds(L.featureGroup(markers).getBounds().pad(0.2));
+    }
+
+    document.querySelectorAll('.post-map-list-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var marker = markers[Number(btn.dataset.index)];
+        if (!marker) return;
+        map.panTo(marker.getLatLng(), { animate: !reducedMotion });
+        marker.openPopup();
+      });
+    });
+  }
+
+  if ('IntersectionObserver' in window) {
+    var io = new IntersectionObserver(function (entries) {
+      if (!entries.some(function (e) { return e.isIntersecting; })) return;
+      io.disconnect();
+      loadLeaflet(init);
+    }, { rootMargin: '200px 0px' });
+    io.observe(el);
+  } else {
+    loadLeaflet(init);
+  }
+})();

--- a/assets/js/travels-filter.js
+++ b/assets/js/travels-filter.js
@@ -1,0 +1,211 @@
+/* /viagens/ — country + year filters that keep the Leaflet map, the
+   "articles by country" table and the URL (?country=&year=) in sync.
+   Data model comes from window.__travelPosts (emitted by Liquid). */
+(function () {
+  'use strict';
+
+  var posts = window.__travelPosts || [];
+  var mapEl = document.getElementById('map');
+  var countrySelect = document.getElementById('travel-filter-country');
+  var yearSelect = document.getElementById('travel-filter-year');
+  var tbody = document.querySelector('.travels-table tbody');
+  if (!posts.length || !mapEl || !countrySelect || !yearSelect || !tbody || !window.L) return;
+
+  var i18n = window.__i18n || {};
+  var countries = (window.__countries || []).reduce(function (acc, c) {
+    if (c && c.slug) acc[c.slug] = c;
+    return acc;
+  }, {});
+
+  var lang = window.__siteLang || 'pt-BR';
+  function t() { return i18n[lang] || i18n[window.__siteLang] || {}; }
+
+  function countryName(key) {
+    var entry = countries[key];
+    if (!entry) return key;
+    var subtag = lang.split('-')[0].toLowerCase();
+    var nameKey = subtag === 'pt' ? 'name' : 'name_' + subtag;
+    return entry[nameKey] || entry.name;
+  }
+
+  // Mirrors the site's date_short ("%d/%m/%Y" / "%m/%d/%Y") on an ISO date.
+  function formatShort(iso) {
+    var parts = iso.split('-');
+    return (t().date_short || '%d/%m/%Y')
+      .replace('%Y', parts[0]).replace('%m', parts[1]).replace('%d', parts[2]);
+  }
+
+  /* ── Map ── */
+  var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var map = L.map('map', {
+    zoomAnimation: !reducedMotion, fadeAnimation: !reducedMotion, markerZoomAnimation: !reducedMotion
+  });
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 18,
+    attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
+  }).addTo(map);
+
+  function buildPopup(post, loc) {
+    var popup = document.createElement('div');
+    var strong = document.createElement('strong');
+    var link = document.createElement('a');
+    link.href = post.url;
+    link.textContent = post.title;
+    strong.appendChild(link);
+    popup.appendChild(strong);
+    popup.appendChild(document.createElement('br'));
+    var small = document.createElement('small');
+    small.style.fontFamily = 'monospace';
+    small.textContent = loc.label + ' · ' + formatShort(post.date);
+    popup.appendChild(small);
+    return popup;
+  }
+
+  var markers = [];
+  posts.forEach(function (post) {
+    post.locations.forEach(function (loc) {
+      if (!Number.isFinite(loc.lat) || !Number.isFinite(loc.lng)) return;
+      var m = L.marker([loc.lat, loc.lng], { alt: loc.label, title: loc.label });
+      m.bindPopup(buildPopup(post, loc));
+      markers.push({ post: post, marker: m });
+    });
+  });
+  var group = L.featureGroup().addTo(map);
+
+  /* ── Filter state ── */
+  var state = { country: '', year: '' };
+
+  function matches(post) {
+    return (!state.country || post.countries.indexOf(state.country) !== -1) &&
+           (!state.year || post.year === state.year);
+  }
+
+  function fitMap() {
+    var visible = group.getLayers();
+    if (visible.length === 1) {
+      map.setView(visible[0].getLatLng(), 8);
+    } else if (visible.length > 1) {
+      map.fitBounds(group.getBounds().pad(0.15));
+    }
+  }
+
+  function renderMap() {
+    group.clearLayers();
+    markers.forEach(function (entry) {
+      if (matches(entry.post)) group.addLayer(entry.marker);
+    });
+    fitMap();
+  }
+
+  /* ── Table — same markup Liquid renders on first paint ── */
+  function renderTable() {
+    var groups = {};
+    posts.filter(matches).forEach(function (post) {
+      post.countries.forEach(function (key) {
+        (groups[key] = groups[key] || []).push(post);
+      });
+    });
+
+    // Liquid sorts by the pt-BR name (code-point order); keep that order.
+    var keys = Object.keys(groups).sort(function (a, b) {
+      var na = countries[a] ? countries[a].name : a;
+      var nb = countries[b] ? countries[b].name : b;
+      return na < nb ? -1 : na > nb ? 1 : 0;
+    });
+
+    tbody.textContent = '';
+
+    if (!keys.length) {
+      var tr = document.createElement('tr');
+      var td = document.createElement('td');
+      td.colSpan = 3;
+      td.className = 'travels-table-empty';
+      td.setAttribute('data-i18n', 'travels_no_results');
+      td.textContent = t().travels_no_results || '';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+
+    keys.forEach(function (key) {
+      var rows = groups[key].slice().sort(function (a, b) { return b.ts - a.ts; });
+      rows.forEach(function (post, i) {
+        var tr = document.createElement('tr');
+
+        if (i === 0) {
+          var tdCountry = document.createElement('td');
+          tdCountry.className = 'travels-table-country';
+          tdCountry.rowSpan = rows.length;
+          if (countries[key]) tdCountry.setAttribute('data-country', key);
+          tdCountry.textContent = countryName(key);
+          tr.appendChild(tdCountry);
+        }
+
+        var tdTitle = document.createElement('td');
+        var a = document.createElement('a');
+        a.href = post.url;
+        a.textContent = post.title;
+        tdTitle.appendChild(a);
+        tr.appendChild(tdTitle);
+
+        var tdDate = document.createElement('td');
+        tdDate.className = 'travels-table-date';
+        tdDate.appendChild(document.createTextNode(formatShort(post.date)));
+        if (post.updated) {
+          tdDate.appendChild(document.createTextNode(' · '));
+          var span = document.createElement('span');
+          span.setAttribute('data-i18n', 'updated_on');
+          span.textContent = t().updated_on || '';
+          tdDate.appendChild(span);
+          tdDate.appendChild(document.createTextNode(' ' + formatShort(post.updated)));
+        }
+        tr.appendChild(tdDate);
+
+        tbody.appendChild(tr);
+      });
+    });
+  }
+
+  /* ── URL ── */
+  function hasOption(select, value) {
+    return Array.prototype.some.call(select.options, function (o) { return o.value === value; });
+  }
+
+  function readUrl() {
+    var params = new URLSearchParams(location.search);
+    var c = params.get('country') || '';
+    var y = params.get('year') || '';
+    state.country = hasOption(countrySelect, c) ? c : '';
+    state.year = hasOption(yearSelect, y) ? y : '';
+    countrySelect.value = state.country;
+    yearSelect.value = state.year;
+  }
+
+  function writeUrl() {
+    var url = new URL(location.href);
+    if (state.country) url.searchParams.set('country', state.country); else url.searchParams.delete('country');
+    if (state.year) url.searchParams.set('year', state.year); else url.searchParams.delete('year');
+    history.replaceState(null, '', url);
+  }
+
+  function apply() {
+    renderMap();
+    renderTable();
+  }
+
+  countrySelect.addEventListener('change', function () { state.country = countrySelect.value; apply(); writeUrl(); });
+  yearSelect.addEventListener('change', function () { state.year = yearSelect.value; apply(); writeUrl(); });
+  document.getElementById('travel-filters').addEventListener('submit', function (e) { e.preventDefault(); });
+
+  // Rows rebuilt here carry data-country / data-i18n so lang-switcher.js keeps
+  // localizing them; dates need a rebuild, so re-render on a language change.
+  document.querySelectorAll('.lang-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () { lang = btn.dataset.lang || lang; renderTable(); });
+  });
+  var active = document.querySelector('.lang-btn--active');
+  if (active && active.dataset.lang) lang = active.dataset.lang;
+
+  readUrl();
+  renderMap();
+  if (state.country || state.year) renderTable();
+})();

--- a/assets/js/travels-filter.js
+++ b/assets/js/travels-filter.js
@@ -71,6 +71,8 @@
     });
   });
   var group = L.featureGroup().addTo(map);
+  var allMarkers = markers.map(function (entry) { return entry.marker; });
+  var emptyNotice = document.getElementById('travel-map-empty');
 
   /* ── Filter state ── */
   var state = { country: '', year: '' };
@@ -80,12 +82,11 @@
            (!state.year || post.year === state.year);
   }
 
-  function fitMap() {
-    var visible = group.getLayers();
-    if (visible.length === 1) {
-      map.setView(visible[0].getLatLng(), 8);
-    } else if (visible.length > 1) {
-      map.fitBounds(group.getBounds().pad(0.15));
+  function fitTo(layers) {
+    if (layers.length === 1) {
+      map.setView(layers[0].getLatLng(), 8);
+    } else if (layers.length > 1) {
+      map.fitBounds(L.featureGroup(layers).getBounds().pad(0.15));
     }
   }
 
@@ -94,7 +95,11 @@
     markers.forEach(function (entry) {
       if (matches(entry.post)) group.addLayer(entry.marker);
     });
-    fitMap();
+    var visible = group.getLayers();
+    // No match: fall back to the all-posts view and say so on the map itself,
+    // rather than leaving an empty map parked on whatever region was last shown.
+    fitTo(visible.length ? visible : allMarkers);
+    if (emptyNotice) emptyNotice.hidden = visible.length > 0;
   }
 
   /* ── Table — same markup Liquid renders on first paint ── */

--- a/travels.html
+++ b/travels.html
@@ -45,21 +45,57 @@ permalink: /viagens/
     <div class="content-wrap">
 
       {% if travel_posts.size > 0 %}
-      <div class="article-card travel-map-card">
-        <div id="map"></div>
-      </div>
-
-      <!-- Card: artigos por país -->
       {% assign all_countries = "" | split: "" %}
+      {% assign all_years = "" | split: "" %}
       {% for post in travel_posts %}
         {% assign _pcs = post.countries %}
         {% if _pcs.size == 0 %}{% assign _pcs = _t.travels_country_unknown | split: "|" %}{% endif %}
         {% for c in _pcs %}
           {% unless all_countries contains c %}{% assign all_countries = all_countries | push: c %}{% endunless %}
         {% endfor %}
+        {% assign _py = post.date | date: "%Y" %}
+        {% unless all_years contains _py %}{% assign all_years = all_years | push: _py %}{% endunless %}
       {% endfor %}
       {% assign all_countries = all_countries | sort %}
+      {% assign all_years = all_years | sort | reverse %}
 
+      <!-- Filtros: país e ano (assets/js/travels-filter.js mantém mapa, tabela e URL em sincronia) -->
+      <div class="article-card travel-filters-card">
+        <form class="travel-filters" id="travel-filters" action="" method="get">
+          <div class="travel-filter">
+            <label for="travel-filter-country" data-i18n="table_country">{{ _t.table_country }}</label>
+            <select id="travel-filter-country" name="country">
+              <option value="" data-i18n="filter_all_countries">{{ _t.filter_all_countries }}</option>
+              {% for country in all_countries %}
+                {% assign _c_entry = nil %}
+                {% for _e in site.data.countries %}
+                  {% if _e.name == country %}{% assign _c_entry = _e %}{% break %}{% endif %}
+                {% endfor %}
+                {% if _c_entry %}
+                <option value="{{ _c_entry.slug }}" data-country="{{ _c_entry.slug }}">{{ _c_entry.name }}</option>
+                {% else %}
+                <option value="{{ country | escape }}">{{ country }}</option>
+                {% endif %}
+              {% endfor %}
+            </select>
+          </div>
+          <div class="travel-filter">
+            <label for="travel-filter-year" data-i18n="filter_year">{{ _t.filter_year }}</label>
+            <select id="travel-filter-year" name="year">
+              <option value="" data-i18n="filter_all_years">{{ _t.filter_all_years }}</option>
+              {% for year in all_years %}
+              <option value="{{ year }}">{{ year }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </form>
+      </div>
+
+      <div class="article-card travel-map-card">
+        <div id="map"></div>
+      </div>
+
+      <!-- Card: artigos por país -->
       <div class="article-card">
         <div class="section-row">
           <h2 class="section-title" data-i18n="travels_table_title">{{ _t.travels_table_title }}</h2>
@@ -131,83 +167,42 @@ permalink: /viagens/
   {% if travel_posts.size > 0 %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js" integrity="sha512-puJW3E/qXDqYp9IfhAI54BJEaWIfloJ7JWs7OeD5i6ruC9JZL1gERT1wjtwXFlh7CjE7ZJ+/vcRZRkIYIb6p4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
-    // Pins gerados pelo Liquid — suporta `location` (objeto) e `locations` (array)
-    const pins = [
+    // Modelo gerado pelo Liquid — um item por post, com `location` (objeto)
+    // e/ou `locations` (array) achatados em `locations`. Países ficam como
+    // slugs de countries.yml (ou o nome cru quando não há entrada).
+    window.__travelPosts = [
       {% for post in travel_posts %}
-
-        {% comment %}── Formato array: locations: [{lat,lng,label}, ...] ──{% endcomment %}
-        {% if post.locations %}
-          {% for loc in post.locations %}
-          {
-            lat:   {{ loc.lat | default: "null" }},
-            lng:   {{ loc.lng | default: "null" }},
-            label: {{ loc.label | jsonify | replace: '</', '<\/' }},
-            title: {{ post.title | jsonify | replace: '</', '<\/' }},
-            date:  {{ post.date | date: '%d/%m/%Y' | jsonify }},
-            url:   {{ post.url | relative_url | jsonify | replace: '</', '<\/' }}
-          },
-          {% endfor %}
-        {% endif %}
-
-        {% comment %}── Formato objeto: location: {lat, lng, label} ──{% endcomment %}
-        {% if post.location %}
-          {% assign loc = post.location %}
-          {
-            lat:   {{ loc.lat | default: "null" }},
-            lng:   {{ loc.lng | default: "null" }},
-            label: {{ loc.label | jsonify | replace: '</', '<\/' }},
-            title: {{ post.title | jsonify | replace: '</', '<\/' }},
-            date:  {{ post.date | date: '%d/%m/%Y' | jsonify }},
-            url:   {{ post.url | relative_url | jsonify | replace: '</', '<\/' }}
-          },
-        {% endif %}
-
+        {% assign _pcs = post.countries %}
+        {% if _pcs.size == 0 %}{% assign _pcs = _t.travels_country_unknown | split: "|" %}{% endif %}
+        {% assign _keys = "" | split: "" %}
+        {% for c in _pcs %}
+          {% assign _key = c %}
+          {% for _e in site.data.countries %}{% if _e.name == c %}{% assign _key = _e.slug %}{% break %}{% endif %}{% endfor %}
+          {% assign _keys = _keys | push: _key %}
+        {% endfor %}
+        {% assign _pub_day = post.date | date: "%Y-%m-%d" %}
+        {% assign _mod_day = post.last_modified_at | date: "%Y-%m-%d" %}
+        {
+          title:     {{ post.title | jsonify | replace: '</', '<\/' }},
+          url:       {{ post.url | relative_url | jsonify | replace: '</', '<\/' }},
+          year:      {{ post.date | date: '%Y' | jsonify }},
+          ts:        {{ post.date | date: '%s' }},
+          date:      {{ post.date | date: '%Y-%m-%d' | jsonify }},
+          updated:   {% if post.last_modified_at and _mod_day != _pub_day %}{{ post.last_modified_at | date: '%Y-%m-%d' | jsonify }}{% else %}null{% endif %},
+          countries: {{ _keys | jsonify }},
+          locations: [
+            {% if post.locations %}{% for loc in post.locations %}
+            { lat: {{ loc.lat | default: "null" }}, lng: {{ loc.lng | default: "null" }}, label: {{ loc.label | jsonify | replace: '</', '<\/' }} },
+            {% endfor %}{% endif %}
+            {% if post.location %}
+            { lat: {{ post.location.lat | default: "null" }}, lng: {{ post.location.lng | default: "null" }}, label: {{ post.location.label | jsonify | replace: '</', '<\/' }} },
+            {% endif %}
+          ]
+        },
       {% endfor %}
     ];
-
-    // Remove o trailing comma do último elemento (gerado pelo Liquid acima)
-    // O array já é válido porque o JS ignora trailing commas em ES5+
-
-    const map = L.map('map');
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 18,
-      attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
-    }).addTo(map);
-
-    function buildPopup(p) {
-      const popup = document.createElement('div');
-
-      const strong = document.createElement('strong');
-      const link = document.createElement('a');
-      link.href = p.url;
-      link.textContent = p.title;
-      strong.appendChild(link);
-      popup.appendChild(strong);
-
-      popup.appendChild(document.createElement('br'));
-
-      const small = document.createElement('small');
-      small.style.fontFamily = 'monospace';
-      small.textContent = `${p.label} · ${p.date}`;
-      popup.appendChild(small);
-
-      return popup;
-    }
-
-    const markers = pins
-      .filter(p => Number.isFinite(p.lat) && Number.isFinite(p.lng))
-      .map(p => {
-        const m = L.marker([p.lat, p.lng]).addTo(map);
-        m.bindPopup(buildPopup(p));
-        return m;
-      });
-
-    if (markers.length === 1) {
-      map.setView([markers[0]._latlng.lat, markers[0]._latlng.lng], 8);
-    } else if (markers.length > 1) {
-      map.fitBounds(L.featureGroup(markers).getBounds().pad(0.15));
-    }
   </script>
+  <script src="{{ '/assets/js/travels-filter.js' | relative_url }}" defer></script>
   {% endif %}
 
   {% include sidebar-script.html %}

--- a/travels.html
+++ b/travels.html
@@ -93,6 +93,7 @@ permalink: /viagens/
 
       <div class="article-card travel-map-card">
         <div id="map"></div>
+        <p class="travel-map-empty" id="travel-map-empty" role="status" hidden data-i18n="travels_no_results">{{ _t.travels_no_results }}</p>
       </div>
 
       <!-- Card: artigos por país -->


### PR DESCRIPTION
## 📑 Description
Introduce a new feature to display mini maps on travel posts, using the Leaflet library. This enhancement allows users to see post locations if the `location` or `locations` front matter attributes are present.

- Add `_includes/post-map.html` to render a mini map for posts.
- Update `_layouts/post.html` to include the mini map for posts with locations.
- Add `assets/js/post-map.js` to lazily load Leaflet scripts and initialize the map.
- Implement a filtering feature on the travels page (`/viagens/`) to filter articles by country and year.
- Create `assets/js/travels-filter.js` to synchronize the map, articles table, and URL filters.
- Adjust CSS (`assets/css/main.css`) for the new map and filter UI components.

These additions enhance user experience by providing an interactive way to explore travel posts geographically and temporally.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Enable geographic and temporal exploration of travel content through post maps and synchronized travels-page filters.

New Features:
- Add interactive mini maps to travel posts with support for single and multiple locations.
- Add country and year filtering to the travels page, keeping the map, article table, and URL state synchronized.

Enhancements:
- Improve map accessibility, responsive styling, dark-theme support, reduced-motion behavior, and empty-filter states.
- Load post-map Leaflet resources lazily and localize the new map and filter interface.